### PR TITLE
Pin Jinja to version 2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 git+git://github.com/canonical/operator
-jinja2
+jinja2 < 3


### PR DESCRIPTION
Pulling a Jinja v3.x makes `charmcraft pack` very unhappy.