### PR TITLE
Pack nrpe_exporter as part of the charm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ build/
 __pycache__/
 *.py[cod]
 
-./nrpe_exporter
+nrpe_exporter-*

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ juju offer microk8s-cluster:cos.prometheus-k8s:metrics-endpoint
 Deploy the cos-proxy charm in a new machine unit on the target model:
 
 ```
-juju deploy -m reactive cos-proxy  # or ./cos-proxy_ubuntu-20.04-amd64.charm --resource nrpe-exporter=./nrpe_exporter
+juju deploy -m reactive cos-proxy  # or ./cos-proxy_ubuntu-20.04-amd64.charm
 juju relate -m reactive telegraf:prometheus-client cos-proxy:prometheus-target
 juju relate -m reactive telegraf:prometheus-rules cos-proxy:prometheus-rules
 ```
@@ -94,11 +94,6 @@ juju relate -m reactive grafana cos-proxy:downstream-grafana-dashboard
 ```
 
 ## NRPE Exporting
-
-The `nrpe_exporter` binary used as a resource can be built from the [nrpe_exporter](https://github.com/canonical/nrpe_exporter)
-repository by cloning and running `make`. `docker` is a build dependency, since `nrpe_exporter` (and `nrpe` itself)
-use older SSL ciphers, and a connection cannot be negotiated in pure Go.
-
 NRPE targets may appear on multiple relations. To capture all jobs, `cos-proxy` should be related to
 **BOTH** an existing reactive NRPE subordinate charm, as well as the application which that charm is subordinated to,
 as the `monitors` interface may appear on either, with the principal charm providing "host-level" checks, and

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -10,3 +10,10 @@ parts:
   charm:
     build-packages:
     - "git"
+  nrpe-exporter:
+    plugin: dump
+    source: .
+    build-packages:
+      - curl
+    override-pull: |
+      curl -L -O https://github.com/canonical/nrpe_exporter/releases/latest/download/nrpe_exporter-${CRAFT_TARGET_ARCH}

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -21,11 +21,6 @@ tags:
 
 series:
   - focal
-resources:
-  nrpe-exporter:
-    type: file
-    filename: nrpe_exporter
-    description: NRPE prometheus exporter
 provides:
   downstream-prometheus-scrape:
     interface: prometheus_scrape

--- a/src/charm.py
+++ b/src/charm.py
@@ -31,6 +31,7 @@ Currently supported interfaces are for:
 """
 
 import logging
+import platform
 import stat
 import textwrap
 from pathlib import Path
@@ -159,15 +160,11 @@ class COSProxyCharm(CharmBase):
 
         # Make sure the exporter binary is present with a systemd service
         if not Path("/usr/local/bin/nrpe_exporter").exists():
-            with open(self.model.resources.fetch("nrpe-exporter"), "rb") as f:
-                with open("/usr/local/bin/nrpe_exporter", "wb") as g:
-                    chunk_size = 4096
-                    chunk = f.read(chunk_size)
-                    while len(chunk) > 0:
-                        g.write(chunk)
-                        chunk = f.read(chunk_size)
+            arch = platform.machine()
+            arch = "amd64" if arch == "x86_64" else arch
+            res = "nrpe_exporter-{}".format(arch)
 
-            st = Path("/usr/local/bin/nrpe_exporter")
+            st = Path(res)
             st.chmod(st.stat().st_mode | stat.S_IEXEC)
 
             systemd_template = textwrap.dedent(

--- a/tox.ini
+++ b/tox.ini
@@ -83,10 +83,13 @@ deps =
     responses
     -r{toxinidir}/requirements.txt
 commands =
+    /usr/bin/env sh -c 'stat nrpe_exporter-amd64 > /dev/null 2>&1 || curl -L -O https://github.com/canonical/nrpe_exporter/releases/latest/download/nrpe_exporter-amd64'
     coverage run \
       --source={[vars]src_path},{[vars]lib_path} \
       -m pytest -v --tb native -s {posargs} {[vars]tst_path}/unit
     coverage report
+allowlist_externals =
+    /usr/bin/env
 
 [testenv:integration]
 description = Run integration tests


### PR DESCRIPTION
## Issue
Align `cos-proxy` with the existing usage of `cos-tool` by packing `nrpe_exporter`.

Closes #20 

