### PR TITLE
Add support for logging 

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -17,3 +17,19 @@ parts:
       - curl
     override-pull: |
       curl -L -O https://github.com/canonical/nrpe_exporter/releases/latest/download/nrpe_exporter-${CRAFT_TARGET_ARCH}
+  vector:
+    plugin: dump
+    source: .
+    build-packages:
+      - curl
+      - tar
+    override-pull: |
+      VERSION=0.27.0
+      if [ $CRAFT_TARGET_ARCH == "amd64" ]; then
+        ARCH=x86_64-unknown-linux-musl
+      elif [ $CRAFT_TARGET_ARCH == "aarch64" ]; then
+        ARCH=aarch64-unknown-linux-musl
+      fi
+
+      VECTOR_URI="https://packages.timber.io/vector/${VERSION}/vector-${VERSION}-${ARCH}.tar.gz"
+      curl -sSfL ${VECTOR_URI} | tar xzf - -C . --strip-components=3 ./vector-${ARCH}/bin/vector

--- a/lib/charms/grafana_k8s/v0/grafana_dashboard.py
+++ b/lib/charms/grafana_k8s/v0/grafana_dashboard.py
@@ -218,7 +218,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 23
+LIBPATCH = 24
 
 logger = logging.getLogger(__name__)
 
@@ -235,9 +235,9 @@ TOPOLOGY_TEMPLATE_DROPDOWNS = [  # type: ignore
         "description": None,
         "error": None,
         "hide": 0,
-        "includeAll": False,
+        "includeAll": True,
         "label": "Juju model",
-        "multi": False,
+        "multi": True,
         "name": "juju_model",
         "query": {
             "query": "label_values(up,juju_model)",
@@ -260,9 +260,9 @@ TOPOLOGY_TEMPLATE_DROPDOWNS = [  # type: ignore
         "description": None,
         "error": None,
         "hide": 0,
-        "includeAll": False,
+        "includeAll": True,
         "label": "Juju model uuid",
-        "multi": False,
+        "multi": True,
         "name": "juju_model_uuid",
         "query": {
             "query": 'label_values(up{juju_model="$juju_model"},juju_model_uuid)',
@@ -285,9 +285,9 @@ TOPOLOGY_TEMPLATE_DROPDOWNS = [  # type: ignore
         "description": None,
         "error": None,
         "hide": 0,
-        "includeAll": False,
+        "includeAll": True,
         "label": "Juju application",
-        "multi": False,
+        "multi": True,
         "name": "juju_application",
         "query": {
             "query": 'label_values(up{juju_model="$juju_model",juju_model_uuid="$juju_model_uuid"},juju_application)',
@@ -310,9 +310,9 @@ TOPOLOGY_TEMPLATE_DROPDOWNS = [  # type: ignore
         "description": None,
         "error": None,
         "hide": 0,
-        "includeAll": False,
+        "includeAll": True,
         "label": "Juju unit",
-        "multi": False,
+        "multi": True,
         "name": "juju_unit",
         "query": {
             "query": 'label_values(up{juju_model="$juju_model",juju_model_uuid="$juju_model_uuid",juju_application="$juju_application"},juju_unit)',
@@ -335,9 +335,9 @@ DATASOURCE_TEMPLATE_DROPDOWNS = [  # type: ignore
         "description": None,
         "error": None,
         "hide": 0,
-        "includeAll": False,
+        "includeAll": True,
         "label": None,
-        "multi": False,
+        "multi": True,
         "name": "prometheusds",
         "options": [],
         "query": "prometheus",
@@ -350,9 +350,9 @@ DATASOURCE_TEMPLATE_DROPDOWNS = [  # type: ignore
         "description": None,
         "error": None,
         "hide": 0,
-        "includeAll": False,
+        "includeAll": True,
         "label": None,
-        "multi": False,
+        "multi": True,
         "name": "lokids",
         "options": [],
         "query": "loki",
@@ -370,7 +370,7 @@ REACTIVE_CONVERTER = {  # type: ignore
     "description": None,
     "error": None,
     "hide": 0,
-    "includeAll": False,
+    "includeAll": True,
     "label": "hosts",
     "multi": True,
     "name": "host",
@@ -622,7 +622,6 @@ def _replace_template_fields(  # noqa: C901
         # Find panels nested under rows
         rows = dict_content.get("rows", {})
         if rows:
-
             for row_idx, row in enumerate(rows):
                 if "panels" in row.keys():
                     rows[row_idx]["panels"] = _template_panels(
@@ -1786,6 +1785,7 @@ class GrafanaDashboardAggregator(Object):
         builtins = self._maybe_get_builtin_dashboards(event)
 
         if not templates and not builtins:
+            logger.warning("NOTHING!")
             return {}
 
         dashboards = {}

--- a/lib/charms/nrpe_exporter/v0/nrpe_exporter.py
+++ b/lib/charms/nrpe_exporter/v0/nrpe_exporter.py
@@ -442,7 +442,7 @@ class NrpeExporterProvider(Object):
                 "juju_application": re.sub(r"^(.*?)[-_]\d+$", r"\1", id.replace("_", "-")),
                 "juju_unit": re.sub(r"^(.*?)[-_](\d+)$", r"\1/\2", id.replace("_", "-")),
                 "nrpe_application": relation.app.name,
-                "nrpe_unit": unit,
+                "nrpe_unit": unit.name,
             },
             "annotations": {
                 "summary": "Unit {{ $labels.juju_unit }}: {{ $labels.command }} critical.",

--- a/lib/charms/observability_libs/v0/juju_topology.py
+++ b/lib/charms/observability_libs/v0/juju_topology.py
@@ -67,6 +67,7 @@ topology = JujuTopology(
 ```
 
 """
+import warnings
 from collections import OrderedDict
 from typing import Dict, List, Optional
 from uuid import UUID
@@ -75,7 +76,7 @@ from uuid import UUID
 LIBID = "bced1658f20f49d28b88f61f83c2d232"
 
 LIBAPI = 0
-LIBPATCH = 3
+LIBPATCH = 5
 
 
 class InvalidUUIDError(Exception):
@@ -87,15 +88,19 @@ class InvalidUUIDError(Exception):
 
 
 class JujuTopology:
-    """JujuTopology is used for storing, generating and formatting juju topology information."""
+    """JujuTopology is used for storing, generating and formatting juju topology information.
+
+    DEPRECATED: This class is deprecated. Use `pip install cosl` and
+    `from cosl.juju_topology import JujuTopology` instead.
+    """
 
     def __init__(
         self,
         model: str,
         model_uuid: str,
         application: str,
-        unit: str = None,
-        charm_name: str = None,
+        unit: Optional[str] = None,
+        charm_name: Optional[str] = None,
     ):
         """Build a JujuTopology object.
 
@@ -115,6 +120,11 @@ class JujuTopology:
             unit: a unit name as a string
             charm_name: name of charm as a string
         """
+        warnings.warn(
+            "observability_libs.v0.juju_topology is deprecated. Use `pip install cosl` instead",
+            category=DeprecationWarning,
+        )
+
         if not self.is_valid_uuid(model_uuid):
             raise InvalidUUIDError(model_uuid)
 
@@ -181,7 +191,10 @@ class JujuTopology:
         )
 
     def as_dict(
-        self, *, remapped_keys: Dict[str, str] = None, excluded_keys: List[str] = None
+        self,
+        *,
+        remapped_keys: Optional[Dict[str, str]] = None,
+        excluded_keys: Optional[List[str]] = None,
     ) -> OrderedDict:
         """Format the topology information into an ordered dict.
 

--- a/lib/charms/vector/v0/vector.py
+++ b/lib/charms/vector/v0/vector.py
@@ -1,0 +1,255 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+"""## Overview.
+
+## Vector Library Usage
+
+The `VectorProvider` object may be used by charms to configure
+Vector, which is a tool which can consume observability data from
+a large number of sources, modify/manipulate it, and send it onwards
+to appropriate 'sinks'.
+
+Vector also provides an equivalent to `node_exporter` so metrics from
+the host itself can be collected.
+"""
+
+import logging
+from typing import Optional
+
+import yaml
+from ops.charm import CharmBase, RelationEvent
+from ops.framework import EventBase, EventSource, Object, ObjectEvents
+
+# The unique Charmhub library identifier, never change it
+LIBID = "0xdeadbeef"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_RELATION_NAMES = {"filebeat": "elastic-beats", "downstream-logging": "loki_push_api"}
+
+DEFAULT_VECTOR_CONFIG = """
+---
+data_dir: /var/lib/vector
+api:
+  enabled: true
+  address: "[::]:8686"
+  playground: false
+enrichment_tables.nrpe:
+  type: file
+enrichment_tables.nrpe.file:
+  path: /etc/vector/nrpe_lookup.csv
+  encoding:
+    type: csv
+enrichment_tables.nrpe.schema:
+  composite_key: string
+  juju_application: string
+  juju_unit: string
+  command: string
+  ipaddr: string
+sources:
+  file:
+    include:
+      - "/var/log/**/*.log"
+    type: file
+    ignore_checkpoints: true
+  nrpe-logs:
+    type: journald
+    since_now: null
+    current_boot_only: true
+    include_units:
+      - nrpe-exporter
+  host_metrics:
+    filesystem:
+      devices:
+        excludes: [binfmt_misc]
+      filesystems:
+        excludes: [binfmt_misc]
+      mountPoints:
+        excludes: ["*/proc/sys/fs/binfmt_misc"]
+    type: host_metrics
+  internal_metrics:
+    type: internal_metrics
+  logstash:
+    address: "[::]:5044"
+    type: logstash
+transforms:
+  enrich-nrpe:
+    type: remap
+    inputs:
+      - nrpe
+    source: |-
+      del(.source_type)
+      fields = parse_key_value!(.message)
+
+      key = join!([fields.address, "_", fields.command])
+      row = get_enrichment_table_record("nrpe", {"composite_key": key}) ?? key
+
+      .juju_unit = row.juju_unit
+      .juju_application = row.juju_application
+      .command = row.command
+      .ip_address = fields.address
+      .duration = fields.duration
+      .return_code = fields.return_code
+      .output = fields.command_output
+  mangle-logstash:
+    type: remap
+    inputs:
+      - logstash
+    source: |-
+      # Remove some fields
+      del(.@metadata)
+      del(.prospector)
+      del(.log)
+      del(.fields.type)
+      del(.input)
+      del(.offset)
+      del(.beat.version)
+
+      .fields.hostname = del(.beat.hostname)
+      del(.beat)
+
+      .fields.juju_unit = del(.fields.juju_principal_unit)
+      .fields.juju_application = replace!(.fields.juju_unit, r'^(?P<app>.*?)/\d+$', "$app")
+
+      structured =
+        parse_syslog(.message) ??
+        parse_common_log(.message) ??
+        parse_regex(.message, r'^(?P<level>\w+)\s(?P<module>[\.\w]+)\s?(?:\[.*?req-(?P<request_id>[-a-z0-9]+).*?\])?\s?(?:\[instance:\s+(?P<instance>[-a-z0-9]+)\])?(?:\[-\])?(?P<msg>.+)') ??
+        {"message": .message}
+      . = merge(., structured)
+
+      del(.host)
+      .timestamp = del(.@timestamp)
+
+      . = flatten(.)
+      . = map_keys(.) -> |key| { replace(key, r'^.*?\.(?P<rest>.*)', "$rest") }
+sinks:
+  prom_exporter:
+    type: prometheus_exporter
+    inputs:
+      - host_metrics
+      - internal_metrics
+    address: "[::]:9090"
+  stdout:
+    inputs:
+      - mangle-logstash
+      - enrich-nrpe
+    type: console
+    encoding:
+      codec: json
+    target: stdout
+  blackhole:
+    type: blackhole
+    inputs:
+      - file
+    print_interval_secs: 10
+    acknowledgements:
+      enabled: true
+"""
+
+
+class VectorConfigChangedEvent(EventBase):
+    """Event emitted when NRPE Exporter targets change."""
+
+    def __init__(self, handle, config: str):
+        super().__init__(handle)
+        self.config = config
+
+    def snapshot(self):
+        """Save target relation information."""
+        return {"config": self.config}
+
+    def restore(self, snapshot):
+        """Restore target relation information."""
+        self.config = snapshot["config"]
+
+
+class VectorEvents(ObjectEvents):
+    """Event descriptor for events raised by `NrpeExporterProvider`."""
+
+    config_changed = EventSource(VectorConfigChangedEvent)
+
+
+class VectorProvider(Object):
+    """An provider for Vector, an observability swiss-army knife."""
+
+    on = VectorEvents()
+
+    def __init__(self, charm: CharmBase, relation_names: Optional[dict] = None):
+        """A Vector exporter.
+
+        Args:
+            charm: a `CharmBase` instance that manages this
+                instance of the NRPE Exporter.
+            relation_names: an optional `dict` containing the interfaces to monitor.
+
+        Raises:
+            RelationNotFoundError: If there is no relation in the charm's metadata.yaml
+                with the same name as provided via `relation_name` argument.
+            RelationInterfaceMismatchError: The relation with the same name as provided
+                via `relation_name` argument does not have the `prometheus_scrape` relation
+                interface.
+            RelationRoleMismatchError: If the relation with the same name as provided
+                via `relation_name` argument does not have the `RelationRole.requires`
+                role.
+        """
+        relation_names = relation_names or DEFAULT_RELATION_NAMES
+
+        super().__init__(charm, "_".join(relation_names.keys()))
+        self._charm = charm
+        self._relation_names = relation_names
+        for relation_name in relation_names.keys():
+            events = self._charm.on[relation_name]
+            self.framework.observe(events.relation_changed, self._on_log_relation_changed)
+            self.framework.observe(events.relation_departed, self._on_log_relation_changed)
+
+    def _on_log_relation_changed(self, event: RelationEvent):
+        """Handle changes with related endpoints.
+
+        Anytime there are changes in relations between the filebeat and/or Loki
+        endpoints, fire an event so the providing charm can fetch the new config
+        and restart vector.
+
+        Args:
+            event: a `RelationEvent` signifying a change.
+        """
+        self.on.config_changed.emit(config=self.config)
+
+    @property
+    def config(self) -> str:
+        """Build a configuration for Vector."""
+        config_template = yaml.safe_load(DEFAULT_VECTOR_CONFIG)
+        loki_endpoints = []
+        loki_sinks = {}
+        for relation_name in self._relation_names.keys():
+            for relation in self._charm.model.relations[relation_name]:
+                if not relation.units:
+                    continue
+                for unit in relation.units:
+                    if endpoint := relation.data[unit].get("endpoint", ""):
+                        loki_endpoints.append(endpoint)
+
+        if loki_endpoints:
+            for idx, endpoint in enumerate(loki_endpoints):
+                loki_sinks.update(
+                    {
+                        f"loki-{idx}": {
+                            "type": "loki",
+                            "inputs": ["logstash", "file", "enrich-nrpe"],
+                            "endpoint": endpoint,
+                            "acknowledgements": {"enabled": True},
+                        }
+                    }
+                )
+
+        config_template["sinks"].update(loki_sinks)
+        return yaml.dump(config_template)

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -26,7 +26,11 @@ provides:
     interface: prometheus_scrape
   downstream-grafana-dashboard:
     interface: grafana_dashboard
+  filebeat:
+    interface: elastic-beats
 requires:
+  downstream-logging:
+    interface: loki_push_api
   prometheus-target:
     interface: http
   prometheus-rules:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -119,7 +119,7 @@ DUMMY_FIXED_2 = {
     '"${prometheusds}", "definition": '
     '"label_values(up{juju_model=\\"$juju_model\\",juju_model_uuid=\\"$juju_model_uuid\\",juju_application=\\"$juju_application\\"},host)", '
     '"description": null, "error": null, "hide": 0, "includeAll": '
-    'false, "label": "hosts", "multi": true, "name": "host", '
+    'true, "label": "hosts", "multi": true, "name": "host", '
     '"options": [], "query": {"query": '
     '"label_values(up{juju_model=\\"$juju_model\\",juju_model_uuid=\\"$juju_model_uuid\\",juju_application=\\"$juju_application\\"},host)", '
     '"refId": "StandardVariableQuery"}, "refresh": 1, "regex": "", '


### PR DESCRIPTION
## Issue
`cos-proxy` did not previously have any support for logging in reactive/machine charms over the `filebeat` interface.

In addition, the output from NRPE commands was not visible, so operators had to manually check on failed jobs.

## Solution
Use [vector](https://vector.dev/) to provide a filebeat-compatible ingestor.

Add support for remote Loki relations as a "sink", and manipulate the input from filebeat and nrpe-exporter journald logs using vector remap language before pushing it off to Loki.

Vector is able to use a lookaside "enrichment table" to provide ancillary data. Since the NRPE exporter itself is not aware of (nor has reason to be) juju topology, use the ip address and command concatenated as a composite key for enrichment table lookups.

Closes #30 

## Testing Instructions
Deploy a machine charm. Deploy and relate to a filebeat subordinate and/or an NRPE. Watch the systemd journal after `juju ssh`-ing into the cos-proxy charm, or relate to Loki and check there.

## Release Notes
Add support for logging 