### PR TITLE
Update nrpe_exporter.py

### DIFF
--- a/lib/charms/nrpe_exporter/v0/nrpe_exporter.py
+++ b/lib/charms/nrpe_exporter/v0/nrpe_exporter.py
@@ -433,7 +433,8 @@ class NrpeExporterProvider(Object):
             "alert": "{}NrpeAlert".format("".join([x.title() for x in cmd.split("_")])),
             # Average over 5 minutes considering a 60 second scrape interval
             "expr": "avg_over_time(command_status{{juju_unit='{}',command='{}'}}[5m]) > 1".format(
-                re.sub(r"^(.*?)[-_](\d+)$", r"\1/\2", id.replace("_", "-"), cmd)
+                re.sub(r"^(.*?)[-_](\d+)$", r"\1/\2", id.replace("_", "-")),
+                cmd
             ),
             "for": "0m",
             "labels": {

--- a/lib/charms/nrpe_exporter/v0/nrpe_exporter.py
+++ b/lib/charms/nrpe_exporter/v0/nrpe_exporter.py
@@ -433,8 +433,7 @@ class NrpeExporterProvider(Object):
             "alert": "{}NrpeAlert".format("".join([x.title() for x in cmd.split("_")])),
             # Average over 5 minutes considering a 60 second scrape interval
             "expr": "avg_over_time(command_status{{juju_unit='{}',command='{}'}}[5m]) > 1".format(
-                re.sub(r"^(.*?)[-_](\d+)$", r"\1/\2", id.replace("_", "-")),
-                cmd
+                re.sub(r"^(.*?)[-_](\d+)$", r"\1/\2", id.replace("_", "-")), cmd
             ),
             "for": "0m",
             "labels": {

--- a/lib/charms/nrpe_exporter/v0/nrpe_exporter.py
+++ b/lib/charms/nrpe_exporter/v0/nrpe_exporter.py
@@ -432,8 +432,8 @@ class NrpeExporterProvider(Object):
         return {
             "alert": "{}NrpeAlert".format("".join([x.title() for x in cmd.split("_")])),
             # Average over 5 minutes considering a 60 second scrape interval
-            "expr": "avg_over_time(command_status{{juju_unit='{}'}}[5m]) > 1".format(
-                re.sub(r"^(.*?)[-_](\d+)$", r"\1/\2", id.replace("_", "-"))
+            "expr": "avg_over_time(command_status{{juju_unit='{}',command='{}'}}[5m]) > 1".format(
+                re.sub(r"^(.*?)[-_](\d+)$", r"\1/\2", id.replace("_", "-"), cmd)
             ),
             "for": "0m",
             "labels": {


### PR DESCRIPTION
## Issue
Alert rules generated by the COS Proxy currently lack filtering by check command, as described in #37.


## Solution
Add a label selector for `command` and set it to the command name.


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
1. Relate COS Proxy to NRPE
2. Make one alert trigger
3. Verify the rest is not.

## Release Notes
<!-- A digestable summary of the change in this PR -->
Filter COS Proxy on-the-fly alert rules by check command.