### PR TITLE
Catch potential error conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,36 @@ juju relate -m reactive prometheus-k8s cos-proxy:downstream-prometheus-scrape
 juju relate -m reactive grafana cos-proxy:downstream-grafana-dashboard
 ```
 
+A complete set of relations on the from the consuming model will appear as:
+
+```
+Model       Controller        Cloud/Region         Version  SLA          Timestamp
+reactive    overlord          localhost/localhost  3.0.3    unsupported  20:40:45+01:00
+
+SAAS     Status  Store               URL
+grafana  active  microk8s            admin/cos.grafana
+loki     active  microk8s            admin/cos.loki
+metrics  active  microk8s            admin/cos.metrics
+
+App        Version  Status  Scale  Charm      Channel  Rev  Exposed  Message
+cos-proxy  n/a      active      1  cos-proxy  edge      15  no       
+filebeat   6.8.23   active      1  filebeat   stable    49  no       Filebeat ready.
+nrpe                active      1  nrpe       stable    97  no       Ready
+telegraf            active      1  telegraf   stable    65  no       Monitoring ubuntu/0 (source version/commit 23.01)
+ubuntu     20.04    active      1  ubuntu     stable    21  no       
+
+Unit           Workload  Agent  Machine  Public address  Ports          Message
+cos-proxy/0*   active    idle   1        10.218.235.237                 
+ubuntu/0*      active    idle   0        10.218.235.198                 
+  filebeat/0*  active    idle            10.218.235.198                 Filebeat ready.
+  nrpe/0*      active    idle            10.218.235.198  icmp,5666/tcp  Ready
+  telegraf/0*  active    idle            10.218.235.198  9103/tcp       Monitoring ubuntu/0 (source version/commit 23.01)
+
+Machine  State    Address         Inst id        Series  AZ  Message
+0        started  10.218.235.198  juju-732594-0  focal       Running
+1        started  10.218.235.237  juju-732594-1  focal       Running
+```
+
 ## NRPE Exporting
 NRPE targets may appear on multiple relations. To capture all jobs, `cos-proxy` should be related to
 **BOTH** an existing reactive NRPE subordinate charm, as well as the application which that charm is subordinated to,

--- a/lib/charms/nrpe_exporter/v0/nrpe_exporter.py
+++ b/lib/charms/nrpe_exporter/v0/nrpe_exporter.py
@@ -434,6 +434,9 @@ class NrpeExporterProvider(Object):
             # Average over 5 minutes considering a 60 second scrape interval
             "expr": "avg_over_time(command_status{{juju_unit='{}',command='{}'}}[5m]) > 1".format(
                 re.sub(r"^(.*?)[-_](\d+)$", r"\1/\2", id.replace("_", "-")), cmd
+            )
+            + " or (absent_over_time(up{{juju_unit='{}'}}[10m]) == 1)".format(
+                re.sub(r"^(.*?)[-_](\d+)$", r"\1/\2", id.replace("_", "-")),
             ),
             "for": "0m",
             "labels": {
@@ -477,6 +480,7 @@ class NrpeExporterProvider(Object):
                 "relabel_configs": [
                     {"source_labels": ["__address__"], "target_label": "__param_target"},
                     {"source_labels": ["__param_target"], "target_label": "instance"},
+                    {"source_labels": ["__param_command"], "target_label": "command"},
                     {
                         "target_label": "__address__",
                         "replacement": "{}:9275".format(exporter_address),

--- a/lib/charms/observability_libs/v0/juju_topology.py
+++ b/lib/charms/observability_libs/v0/juju_topology.py
@@ -67,7 +67,6 @@ topology = JujuTopology(
 ```
 
 """
-import warnings
 from collections import OrderedDict
 from typing import Dict, List, Optional
 from uuid import UUID
@@ -76,7 +75,7 @@ from uuid import UUID
 LIBID = "bced1658f20f49d28b88f61f83c2d232"
 
 LIBAPI = 0
-LIBPATCH = 5
+LIBPATCH = 6
 
 
 class InvalidUUIDError(Exception):
@@ -120,11 +119,6 @@ class JujuTopology:
             unit: a unit name as a string
             charm_name: name of charm as a string
         """
-        warnings.warn(
-            "observability_libs.v0.juju_topology is deprecated. Use `pip install cosl` instead",
-            category=DeprecationWarning,
-        )
-
         if not self.is_valid_uuid(model_uuid):
             raise InvalidUUIDError(model_uuid)
 

--- a/lib/charms/operator_libs_linux/v1/systemd.py
+++ b/lib/charms/operator_libs_linux/v1/systemd.py
@@ -60,7 +60,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 0
+LIBPATCH = 1
 
 
 class SystemdError(Exception):
@@ -131,7 +131,7 @@ def service_running(service_name: str) -> bool:
     """Determine whether a system service is running.
 
     Args:
-        service_name: the name of the service
+        service_name: the name of the service to check
     """
     return _systemctl("is-active", service_name, quiet=True)
 
@@ -140,7 +140,7 @@ def service_start(service_name: str) -> bool:
     """Start a system service.
 
     Args:
-        service_name: the name of the service to stop
+        service_name: the name of the service to start
     """
     return _systemctl("start", service_name)
 

--- a/lib/charms/vector/v0/vector.py
+++ b/lib/charms/vector/v0/vector.py
@@ -38,6 +38,9 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_RELATION_NAMES = {"filebeat": "elastic-beats", "downstream-logging": "loki_push_api"}
 
+# `$` is interpolated in the actual config, so use `$$` to use `$capture_group`
+# comment is here because otherwise Python's YAML serializer does the wrong thing,
+# and VRL tries to interpret it
 DEFAULT_VECTOR_CONFIG = """
 ---
 data_dir: /var/lib/vector
@@ -125,7 +128,6 @@ transforms:
       .juju_unit = .fields.juju_principal_unit
       del(.fields)
 
-      # `$` is interpolated in the actual config, so use `$$` to use `$capture_group`
       .juju_application = replace!(.juju_unit, r'^(?P<app>.*?)/\d+$', "$$app")
 
       structured =


### PR DESCRIPTION
## Issue
PyYAML gets confused when serializing the Vector config, and it's a multi-line YAML string with newlines (as literal `\n`), which may case vector to try to interpret a commented line. Move the comment.

If Vector cannot reach a Loki sink, it may not start (or fail to restart). Try to connect to the endpoints and, if they cannot be reached, go into `BlockedStatus` and skip writing the new config so it stays up.

Add an `absent_over_time` check to the automatic NRPE alerts so "Schroedinger's metrics" still alert also.
