### PR TITLE
add build for jammy

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -6,6 +6,12 @@ bases:
     run-on:
     - name: "ubuntu"
       channel: "20.04"
+  - build-on:
+    - name: "ubuntu"
+      channel: "22.04"
+    run-on:
+    - name: "ubuntu"
+      channel: "22.04"
 parts:
   charm:
     build-packages:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -21,6 +21,7 @@ tags:
 
 series:
   - focal
+  - jammy
 provides:
   downstream-prometheus-scrape:
     interface: prometheus_scrape


### PR DESCRIPTION
## Issue
this pr solve issue #43 


## Solution
Adds support for Ubuntu 22.04 (Jammy Jellyfish) in charmcraft.yaml and metadata.yaml:
- Adds a build-on section for Ubuntu 22.04.
- Adds a run-on section for Ubuntu 22.04.
- Updates series in metadata.yaml to include jammy.


## Testing Instructions
- run charmcraft pack
- deploy cos-proxy_ubuntu-22.04-amd64.charm

## Release Notes
- Added support for Ubuntu 22.04 (Jammy Jellyfish) in charmcraft.yaml and metadata.yaml.
- Updated series field in metadata.yaml to include jammy.