### PR TITLE
fix issues with the series

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -2,14 +2,10 @@ type: charm
 bases:
   - build-on:
     - name: "ubuntu"
-      channel: "20.04"
-    run-on:
-    - name: "ubuntu"
-      channel: "20.04"
-  - build-on:
-    - name: "ubuntu"
       channel: "22.04"
     run-on:
+    - name: "ubuntu"
+      channel: "20.04"
     - name: "ubuntu"
       channel: "22.04"
 parts:


### PR DESCRIPTION
## Issue
The current setup produces multiple charm files, one for each `builds-on`. 

## Solution
This can safely be combined into one, creating a single charm file for both `20.04` and `22.04`

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
N/A

## Testing Instructions
- `juju deploy ./*.charm proxy-jammy --series jammy`
- `juju deploy ./*.charm proxy-focal --series focal`

## Release Notes
Add support for jammy.