### PR TITLE
Use a stricter regex for label matching for MAAS

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -370,7 +370,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 35
+LIBPATCH = 36
 
 logger = logging.getLogger(__name__)
 
@@ -2248,7 +2248,7 @@ class MetricsEndpointAggregator(Object):
                 logger.debug("Could not perform DNS lookup for %s", target["hostname"])
                 dns_name = target["hostname"]
             extra_info["dns_name"] = dns_name
-        label_re = re.compile(r'(?P<label>juju.*?)="(?P<value>.*?)",?')
+        label_re = re.compile(r'[,{](?P<label>juju_[amu].*?)="(?P<value>.*?)",?')
 
         try:
             with urlopen(f'http://{target["hostname"]}:{target["port"]}/metrics') as resp:

--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -2248,7 +2248,7 @@ class MetricsEndpointAggregator(Object):
                 logger.debug("Could not perform DNS lookup for %s", target["hostname"])
                 dns_name = target["hostname"]
             extra_info["dns_name"] = dns_name
-        label_re = re.compile(r'[,{](?P<label>juju_[amu].*?)="(?P<value>.*?)",?')
+        label_re = re.compile(r'[,{]\s?(?P<label>juju_[amu].*?)="(?P<value>.*?)",?')
 
         try:
             with urlopen(f'http://{target["hostname"]}:{target["port"]}/metrics') as resp:


### PR DESCRIPTION
## Issue
Machines managed by Juju in MAAS _may_ be named `juju...`, which causes the prior regex to potentially match something such as `some_metric{host="model:jujulxd...", juju_application="foo", ...}` to accidentally swallow the whole thing.

Restrict it so it must start with `{` or `,` and be followed with `_[amu].*?` (`application|model|model_uuid|unit`) to minimize this risk.

## Release Notes
Use a stricter regex for label matching for MAAS