### PR TITLE
Be even stricter and enforce a negative lookbehind to wrangle ceph-mons

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -2248,7 +2248,7 @@ class MetricsEndpointAggregator(Object):
                 logger.debug("Could not perform DNS lookup for %s", target["hostname"])
                 dns_name = target["hostname"]
             extra_info["dns_name"] = dns_name
-        label_re = re.compile(r'[,{]\s?(?P<label>juju_[amu].*?)="(?P<value>.*?)",?')
+        label_re = re.compile(r'[{,]\s?(?<!")(?P<label>juju_[amu].*?)="(?P<value>.*?)",?')
 
         try:
             with urlopen(f'http://{target["hostname"]}:{target["port"]}/metrics') as resp:


### PR DESCRIPTION
## Issue
There was a risk of the previous capture, with `ceph-mon`, returning values such as:

```json
{
    "targets": [
        "10.95.155.32:9283"
    ],
    "labels": {
        "juju_model": "microk8s",
        "juju_model_uuid": "ce085f22-7205-474e-8d1e-36a7c5c20a9a",
        "juju_application": "ceph-mon",
        "juju_unit": "ceph-mon/1",
        "host": "10.95.155.32",
        "dns_name": "eth2.juju-c20a9a-2-lxd-0.van3",
        "juju-c20a9a-2-lxd-0\",hostname": "juju-c20a9a-2-lxd-0",
        "juju-c20a9a-3-lxd-0\",hostname": "juju-c20a9a-3-lxd-0",
        "juju-c20a9a-1-lxd-0\",hostname": "juju-c20a9a-1-lxd-0",
        "juju-c20a9a-0-lxd-0\",hostname": "juju-c20a9a-0-lxd-0",
        "juju-c20a9a-1-lxd-1\",hostname": "juju-c20a9a-1-lxd-1",
        "juju-c20a9a-2-lxd-1\",hostname": "juju-c20a9a-2-lxd-1"
    }
}
```

While the last patch covered this, we can be even stricter. 

<img width="1400" alt="image" src="https://user-images.githubusercontent.com/82836126/233454361-6e261c65-adb8-40e1-a8b7-899d5d352d51.png">


## Release Notes
Be even stricter and enforce a negative lookbehind to wrangle ceph-mons