### PR TITLE
use ruff instead of flake8

### DIFF
--- a/lib/charms/nrpe_exporter/v0/nrpe_exporter.py
+++ b/lib/charms/nrpe_exporter/v0/nrpe_exporter.py
@@ -28,7 +28,7 @@ import json
 import logging
 import re
 from json.decoder import JSONDecodeError
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, List, Optional, Tuple
 
 import yaml
 from ops.charm import CharmBase, RelationEvent, RelationRole
@@ -195,6 +195,7 @@ def find_key(d: dict, key: str) -> Any:
         val = find_key(child, key)
         if val:
             return val
+    return None
 
 
 class NrpeTargetsChangedEvent(EventBase):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,28 +13,26 @@ show_missing = true
 line-length = 99
 target-version = ["py38"]
 
-[tool.isort]
-profile = "black"
-
 # Linting tools configuration
-[tool.flake8]
-max-line-length = 99
-max-doc-length = 99
-exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
-select = ["E", "W", "F", "C", "N", "R", "D", "H"]
-# Ignore W503, E501 because using black creates errors with this
+[tool.ruff]
+line-length = 99
+extend-exclude = ["__pycache__", "*.egg_info"]
+select = ["E", "W", "F", "C", "N", "R", "D", "I001"]
+# Ignore E501 because using black creates errors with this
 # Ignore D107 Missing docstring in __init__
-ignore = ["W503", "E501", "D107"]
+# Ignore W605 as it doesn't recognize raw strings
+ignore = ["E501", "D107", "W605", "RET504"]
+
+[tool.ruff.per-file-ignores]
 # D100, D101, D102, D103: Ignore missing docstrings in tests
-per-file-ignores = [
-  "tests/*:D100,D101,D102,D103",
-  "lib/charms/nrpe_exporter/*:C901"
-]
-docstring-convention = "google"
-# Check for properly formatted copyright header in each file
-copyright-check = "True"
-copyright-author = "Canonical Ltd."
-copyright-regexp = "Copyright\\s\\d{4}([-,]\\d{4})*\\s+%(author)s"
+"tests/*" = ["D100","D101","D102","D103"]
+"lib/charms/nrpe_exporter/*" = ["C901"]
+
+[tool.ruff.pydocstyle]
+convention = "google"
+
+[tool.ruff.mccabe]
+max-complexity = 10
 
 # Static analysis tools configuration
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,9 +31,6 @@ ignore = ["E501", "D107", "W605", "RET504"]
 [tool.ruff.pydocstyle]
 convention = "google"
 
-[tool.ruff.mccabe]
-max-complexity = 10
-
 # Static analysis tools configuration
 [tool.mypy]
 pretty = true

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -22,10 +22,9 @@ import unittest
 import uuid
 from unittest.mock import patch
 
+from charm import COSProxyCharm
 from ops.model import BlockedStatus
 from ops.testing import Harness
-
-from charm import COSProxyCharm
 
 ALERT_RULE_1 = """- alert: CPU_Usage
   expr: cpu_usage_idle{is_container!=\"True\", group=\"promoagents-juju\"} < 10

--- a/tox.ini
+++ b/tox.ini
@@ -31,30 +31,21 @@ passenv =
 description = Apply coding style standards to code
 deps =
     black
-    isort
+    ruff
 commands =
-    isort {[vars]all_path}
+    ruff --fix {[vars]all_path}
     black {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 deps =
     black
+    ruff
     codespell
-    # Pinned until pyproject-flake8 supports flake8 >= 5
-    flake8 < 5
-    flake8-docstrings
-    flake8-copyright
-    flake8-builtins
-    pyproject-flake8
-    pep8-naming
-    isort
 commands =
     codespell {[vars]lib_path}
     codespell . --skip .git --skip .tox --skip build --skip lib --skip venv* --skip .mypy_cache
-    # pflake8 wrapper supports config from pyproject.toml
-    pflake8 {[vars]all_path}
-    isort --check-only --diff {[vars]all_path}
+    ruff {[vars]all_path}
     black --check --diff {[vars]all_path}
 
 [testenv:static-{charm,lib,unit}]


### PR DESCRIPTION
The **flake8** plugins we use are re-implemented in **ruff**, which is why they have been removed from the dependencies.

**isort** is enabled (and used when formatting) through the `I001` rule.

The "exclude list" has been updated to omit folders that **ruff** excludes by default.

Everything else is the same, the only difference being two new rules being ignored (which weren't check before anyway): 
* `W605: Invalid escape sequence`, as it wasn't recognizing raw strings for some reason;
* `RET504: Unnecessary variable assignment before return statement`, which we do everywhere as it increases readability.