### PR TITLE
scrape internal metrics and host metrics more sparingly

### DIFF
--- a/lib/charms/nrpe_exporter/v0/nrpe_exporter.py
+++ b/lib/charms/nrpe_exporter/v0/nrpe_exporter.py
@@ -149,7 +149,7 @@ def _validate_relation_by_interface_and_direction(
     relation = charm.meta.relations[relation_name]
 
     actual_relation_interface = relation.interface_name
-    if actual_relation_interface != expected_relation_interface:
+    if actual_relation_interface and actual_relation_interface != expected_relation_interface:
         raise RelationInterfaceMismatchError(
             relation_name, expected_relation_interface, actual_relation_interface
         )

--- a/lib/charms/vector/v0/vector.py
+++ b/lib/charms/vector/v0/vector.py
@@ -30,7 +30,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 
 logger = logging.getLogger(__name__)

--- a/lib/charms/vector/v0/vector.py
+++ b/lib/charms/vector/v0/vector.py
@@ -76,9 +76,11 @@ sources:
         excludes: [binfmt_misc]
       mountPoints:
         excludes: ["*/proc/sys/fs/binfmt_misc"]
+    scrape_interval_secs: 60
     type: host_metrics
   internal_metrics:
     type: internal_metrics
+    scrape_interval_secs: 60
   logstash:
     address: "0.0.0.0:5044"
     type: logstash


### PR DESCRIPTION
This **might** resolve #70, as it will divide the metric ingestion rate by 60 for internal metrics and by 4 for host metrics, giving Vector plenty of time to garbage collect and flush the metrics to the prometheus_exporter sink.

## Issue
The default for scraping internal metrics and host metrics in Vector is every second for internal metrics and every 15 seconds for host metrics. This is **way** to excessive and creates pressure on Prometheus.


## Solution
<!-- A summary of the solution addressing the above issue -->
Change the interval to every minute for both. 

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->
Deploy it and make sure metrics come in at the expected interval.

## Release Notes
<!-- A digestable summary of the change in this PR -->
Scrape internal metrics and host metrics more sparingly.