### PR TITLE
make nrpe alert rule legend look like yaml

### DIFF
--- a/lib/charms/nrpe_exporter/v0/nrpe_exporter.py
+++ b/lib/charms/nrpe_exporter/v0/nrpe_exporter.py
@@ -460,10 +460,10 @@ class NrpeExporterProvider(Object):
                 "Unit = {{ $labels.juju_unit }}\n"
                 "Value = {{ $value }}\n"
                 "Legend:\n"
-                "\tStatusOK        = 0\n"
-                "\tStatusWarning   = 1\n"
-                "\tStatusCritical  = 2\n"
-                "\tStatusUnknown   = 3",
+                "  - StatusOK       = 0\n"
+                "  - StatusWarning  = 1\n"
+                "  - StatusCritical = 2\n"
+                "  - StatusUnknown  = 3",
             },
         }
 


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
Fixes issue #74.

Lines starting with `\t` after `Legend:` break any tools that try to parse Legend as yaml.

## Solution
<!-- A summary of the solution addressing the above issue -->
Defining Legend as an array fixes the issue. It also makes it consistent with other sections such as Labels or Annotations.


## Context
<!-- What is some specialized knowledge relevant to this project/technology -->
```
>>> legend = '''Legend:
... \tStatusOK        = 0
... \tStatusWarning   = 1
... \tStatusCritical  = 2
... \tStatusUnknown   = 3'''
>>> yaml.safe_load(legend)
...
yaml.scanner.ScannerError: while scanning for the next token
found character '\t' that cannot start any token
```

versus

```
>>> legend = '''Legend:
...   - StatusOK       = 0
...   - StatusWarning  = 1
...   - StatusCritical = 2
...   - StatusUnknown  = 3'''
>>> yaml.safe_load(legend)
{'Legend': ['StatusOK       = 0', 'StatusWarning  = 1', 'StatusCritical = 2', 'StatusUnknown  = 3']}
```

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Release Notes
<!-- A digestable summary of the change in this PR -->
Fixed formatting of the NRPE alert Legend.
