### PR TITLE
Fix error on checking for loki endpoints

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -42,6 +42,7 @@ from csv import DictReader, DictWriter
 from pathlib import Path
 from typing import Any, Dict, List, Optional, cast
 from urllib import request
+from urllib.error import URLError
 
 from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardAggregator
 from charms.nrpe_exporter.v0.nrpe_exporter import (
@@ -390,15 +391,20 @@ class COSProxyCharm(CharmBase):
 
         if loki_endpoints:
             for e in loki_endpoints:
+                dest = re.sub(r"^(.*?/loki/api/v1)/push$", r"\1/series", e)
                 try:
-                    dest = re.sub(r"^(.*?/loki/api/v1)/push$", r"\1/series", e)
                     r = request.urlopen(dest)
                     if r.code != 200:
                         self.unit.status = BlockedStatus(
                             "One or more Loki endpoints is not reachable!"
                         )
                         return
-                except request.HTTPError:
+                except URLError as e:
+                    logger.warning(
+                        "Error connecting to Loki endpoints: %s (url: %s)",
+                        e,
+                        dest,
+                    )
                     self.unit.status = BlockedStatus(
                         "One or more Loki endpoints is not reachable!"
                     )


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
If there was an error that HTTPError didn't cover,
such as an error in name resolution,
urllib.request.urlopen may raise URLError instead of HTTPError.
URLError is the parent class for all exceptions that may be raised
by urlopen.

When this happens, currently, the charm will error out with a traceback

## Solution
<!-- A summary of the solution addressing the above issue -->
We should catch the URLError exception instead.

Also add logging to help with debugging in the case of such errors.

This results in an informative error in the logs:

```
unit-cos-proxy-0: 05:20:30 WARNING unit.cos-proxy/0.juju-log filebeat:162: Error connecting to Loki endpoints: <urlopen error [Errno -2] Name or service not known> (url: http://myexampleurlthatdoesntresolve.com)
```

And the status being set to "One or more Loki endpoints is not reachable!" as expected.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

- deploy the charm, including a related cos stack with loki
- do something so that the loki endpoint is not resolvable (maybe temporarily edit the charm code above the chang to set `dest` to some invalid url)
- view the charm status and verify that we see a message like 'one or more loki endpoints is not reachable', and a warning in the debug-log about the error and url it tried to reach.

## Release Notes
<!-- A digestable summary of the change in this PR -->
