### PR TITLE
Fix nrpes var init

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -447,7 +447,11 @@ class COSProxyCharm(CharmBase):
                     a["labels"]["juju_unit"],  # type: ignore
                 )
 
-        nrpes = cast(List[Dict[str, Any]], event.current_targets)
+            nrpes = cast(List[Dict[str, Any]], event.current_targets)
+        else:
+            # If the event arg is None, then the stored state value is already up to date.
+            nrpes = self.nrpe_exporter.endpoints()
+
         self._modify_enrichment_file(endpoints=nrpes)
 
         for nrpe in nrpes:


### PR DESCRIPTION
## Issue
When `_on_nrpe_targets_changed` is called with no event arg (event=None), the nrpes variable cannot be init'ed from it.

## Solution
- [x] Initialize the nrpes variable from stored state. If the event arg is None, then at this point the stored state value is already up to date.
- [ ] Add relevant tests

Fixes #92.
