### PR TITLE
Do not keep stale targets in csv file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 venv/
 build/
 *.charm

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # COS Proxy charm
 
+[![Charmhub Badge](https://charmhub.io/cos-proxy/badge.svg)](https://charmhub.io/cos-proxy)
+[![Release](https://github.com/canonical/cos-proxy-operator/actions/workflows/release.yaml/badge.svg)](https://github.com/canonical/cos-proxy-operator/actions/workflows/release.yaml)
+[![Discourse Status](https://img.shields.io/discourse/status?server=https%3A%2F%2Fdiscourse.charmhub.io&style=flat&label=CharmHub%20Discourse)](https://discourse.charmhub.io)
+
+
 This Juju machine charm that provides a single integration point in the machine world
 with the Kubernetes-based [COS bundle](https://charmhub.io/cos-lite).
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -3,25 +3,17 @@
 name: cos-proxy
 
 description: |
-  This Juju machine charm that provides a single integration point in the machine world with Kubernetes-based Canonical Observability Stack
+  This Juju machine charm that provides a single integration point in the machine world with Kubernetes-based Canonical
+  Observability Stack
 
 summary: |
   Single integration point in the machine world with Kubernetes-based COS
 docs: https://discourse.charmhub.io/t/cos-proxy-operator-docs-index/5611
 
-tags:
-  - observability
-  - lma
-  - cos
-  - monitoring
-  - logging
-  - alerting
-  - grafana
-  - nrpe
-
 series:
   - focal
   - jammy
+
 provides:
   downstream-grafana-dashboard:
     interface: grafana_dashboard
@@ -29,6 +21,7 @@ provides:
     interface: prometheus_scrape
   filebeat:
     interface: elastic-beats
+
 requires:
   dashboards:
     interface: grafana-dashboard

--- a/src/charm.py
+++ b/src/charm.py
@@ -329,7 +329,7 @@ class COSProxyCharm(CharmBase):
 
             unit_name = next(
                 filter(
-                    lambda d: "target_label" in d and d["target_label"] == "juju_unit",
+                    lambda d: "target_label" in d and d["target_label"] == "juju_unit",  # type: ignore
                     endpoint["additional_fields"]["relabel_configs"],
                 )
             )["replacement"]

--- a/tests/unit/test_relation_monitors.py
+++ b/tests/unit/test_relation_monitors.py
@@ -1,5 +1,3 @@
-import base64
-import lzma
 import tempfile
 import unittest
 from pathlib import Path
@@ -9,10 +7,6 @@ from charm import COSProxyCharm
 from ops.testing import Harness
 
 
-@patch.object(lzma, "compress", new=lambda x, *args, **kwargs: x)
-@patch.object(lzma, "decompress", new=lambda x, *args, **kwargs: x)
-@patch.object(base64, "b64encode", new=lambda x: x)
-@patch.object(base64, "b64decode", new=lambda x: x)
 class TestRelationMonitors(unittest.TestCase):
     def setUp(self):
         self.mock_enrichment_file = Path(tempfile.mktemp())

--- a/tests/unit/test_relation_monitors.py
+++ b/tests/unit/test_relation_monitors.py
@@ -2,7 +2,6 @@ import base64
 import lzma
 import tempfile
 import unittest
-import uuid
 from pathlib import Path
 from unittest.mock import patch
 
@@ -12,7 +11,6 @@ from ops.testing import Harness
 
 @patch.object(lzma, "compress", new=lambda x, *args, **kwargs: x)
 @patch.object(lzma, "decompress", new=lambda x, *args, **kwargs: x)
-@patch.object(uuid, "uuid4", new=lambda: "21838076-1191-4a88-8008-234433115007")
 @patch.object(base64, "b64encode", new=lambda x: x)
 @patch.object(base64, "b64decode", new=lambda x: x)
 class TestRelationMonitors(unittest.TestCase):
@@ -30,6 +28,7 @@ class TestRelationMonitors(unittest.TestCase):
 
         self.harness = Harness(COSProxyCharm)
         self.addCleanup(self.harness.cleanup)
+        self.harness.set_model_info(name="mymodel", uuid="fe2c9bbb-58ab-40e4-8f70-f27480093fca")
         self.harness.set_leader(True)
         self.harness.begin_with_initial_hooks()
 

--- a/tests/unit/test_relation_monitors.py
+++ b/tests/unit/test_relation_monitors.py
@@ -1,0 +1,84 @@
+import base64
+import lzma
+import tempfile
+import unittest
+import uuid
+from pathlib import Path
+from unittest.mock import patch
+
+from charm import COSProxyCharm
+from ops.testing import Harness
+
+
+@patch.object(lzma, "compress", new=lambda x, *args, **kwargs: x)
+@patch.object(lzma, "decompress", new=lambda x, *args, **kwargs: x)
+@patch.object(uuid, "uuid4", new=lambda: "21838076-1191-4a88-8008-234433115007")
+@patch.object(base64, "b64encode", new=lambda x: x)
+@patch.object(base64, "b64decode", new=lambda x: x)
+class TestRelationMonitors(unittest.TestCase):
+    def setUp(self):
+        self.mock_enrichment_file = Path(tempfile.mktemp())
+
+        for p in [
+            patch("charm.remove_package"),
+            patch.object(COSProxyCharm, "_setup_nrpe_exporter"),
+            patch.object(COSProxyCharm, "_start_vector"),
+            patch.object(COSProxyCharm, "path", property(lambda *_: self.mock_enrichment_file)),
+        ]:
+            p.start()
+            self.addCleanup(p.stop)
+
+        self.harness = Harness(COSProxyCharm)
+        self.addCleanup(self.harness.cleanup)
+        self.harness.set_leader(True)
+        self.harness.begin_with_initial_hooks()
+
+    def tearDown(self):
+        self.mock_enrichment_file.unlink(missing_ok=True)
+
+    def test_monitors_changed(self):
+        # The unit data below were obtained from the output of:
+        # juju show-unit \
+        #   cos-proxy/0 --format json | jq '."cos-proxy/0"."relation-info"[0]."related-units"."nrpe/0".data'
+        self.harness.add_network("10.41.168.226")
+
+        unit_data = {
+            "egress-subnets": "10.41.168.226/32",
+            "ingress-address": "10.41.168.226",
+            "machine_id": "1",
+            "model_id": "fe2c9bbb-58ab-40e4-8f70-f27480093fca",
+            "monitors": "{'monitors': {'remote': {'nrpe': {'check_conntrack': 'check_conntrack', 'check_systemd_scopes': 'check_systemd_scopes', 'check_reboot': 'check_reboot'}}}, 'version': '0.3'}",
+            "private-address": "10.41.168.226",
+            "target-address": "10.41.168.226",
+            "target-id": "ubuntu-0",
+        }
+        rel_id = self.harness.add_relation("monitors", "nrpe")
+        self.harness.add_relation_unit(rel_id, "nrpe/0")
+        self.harness.update_relation_data(rel_id, "nrpe/0", unit_data)
+
+        expected = "\n".join(
+            [
+                "composite_key,juju_application,juju_unit,command,ipaddr",
+                "10.41.168.226_check_conntrack,ubuntu,ubuntu/0,check_conntrack,10.41.168.226",
+                "10.41.168.226_check_systemd_scopes,ubuntu,ubuntu/0,check_systemd_scopes,10.41.168.226",
+                "10.41.168.226_check_reboot,ubuntu,ubuntu/0,check_reboot,10.41.168.226",
+                "",
+            ]
+        )
+        self.assertEqual(expected, self.mock_enrichment_file.read_text())
+
+        # The following simulates `juju config nrpe nagios_host_context="context-1"`
+        self.harness.update_relation_data(
+            rel_id, "nrpe/0", {**unit_data, **{"target-id": "context-1-ubuntu-0"}}
+        )
+
+        expected = "\n".join(
+            [
+                "composite_key,juju_application,juju_unit,command,ipaddr",
+                "10.41.168.226_check_conntrack,context-1-ubuntu,context-1-ubuntu/0,check_conntrack,10.41.168.226",
+                "10.41.168.226_check_systemd_scopes,context-1-ubuntu,context-1-ubuntu/0,check_systemd_scopes,10.41.168.226",
+                "10.41.168.226_check_reboot,context-1-ubuntu,context-1-ubuntu/0,check_reboot,10.41.168.226",
+                "",
+            ]
+        )
+        self.assertEqual(expected, self.mock_enrichment_file.read_text())


### PR DESCRIPTION
## Issue
When nrpe changed prefix, cos-proxy failed to correctly calculate the current list of targets, keeping stale rows in the file.

## Solution
Make sure stale targets are not kept, by correctly looking up entries in the csv.

Fixes #93.
