### PR TITLE
Add `current_alerts` to `NrpeTargetsChangedEvent`

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -462,7 +462,7 @@ class COSProxyCharm(CharmBase):
 
             nrpes = cast(List[Dict[str, Any]], event.current_targets)
         else:
-            # If the event arg is None, then the stored state value is already up to date.
+            # If the event arg is None, then the stored state value is already up-to-date.
             nrpes = self.nrpe_exporter.endpoints()
 
         self._modify_enrichment_file(endpoints=nrpes)
@@ -472,8 +472,7 @@ class COSProxyCharm(CharmBase):
                 nrpe["target"], nrpe["app_name"], **nrpe["additional_fields"]
             )
 
-        alerts = self.nrpe_exporter.alerts()
-        for alert in alerts:
+        for alert in event.current_alerts:
             self.metrics_aggregator.set_alert_rule_data(
                 re.sub(r"/", "_", alert["labels"]["juju_unit"]),
                 alert,


### PR DESCRIPTION
## Issue
As part of #89, we now update stored state only after relation data.
But emission of custom events is [nested, not queued](https://github.com/canonical/operator/issues/1070).
Due to the code ordering in the charm, the custom event handler was getting data from stored state that was't updated yet.

## Solution
Add "current alerts" to the lib's event data so that charm code won't need to fetch it from stored state.

Fixes #99.

## Context
Note that cos-proxy adheres very strongly to delta-charming. As a result, upgrading the charm to this revision will not resolve the issues described in #99.
I imagine that only a rewrite of key handlers to be holistic would help with resolving gaps on upgrade.

## Testing Instructions
I confirmed the issue and the fix using the following bundle.
- scale up/down the ubuntu charm
- add/remove the glance relation

```mermaid
graph LR

subgraph k8s
prometheus
end

subgraph lxd
cos-proxy --- |monitors| nrpe
glance ---|nrpe_external_master| nrpe
nrpe ---|general-info| ubuntu
end

prometheus --- cos-proxy
```

```yaml
series: jammy
saas:
  prom:
    url: k8s2:admin/auth2.prom
applications:
  cos-proxy:
    charm: local:cos-proxy-0
    series: focal
    num_units: 1
    to:
    - "5"
    constraints: arch=amd64
  nrpe:
    charm: nrpe
    channel: edge
    revision: 114
  ubuntu:
    charm: ubuntu
    channel: edge
    revision: 24
    num_units: 3
    to:
    - "1"
    - "3"
    - "6"
    constraints: arch=amd64
    storage:
      block: loop,100M
      files: rootfs,100M
machines:
  "1":
    constraints: arch=amd64
  "3":
    constraints: arch=amd64
  "5":
    constraints: arch=amd64
    series: focal
  "6":
    constraints: arch=amd64
relations:
- - nrpe:general-info
  - ubuntu:juju-info
- - cos-proxy:downstream-prometheus-scrape
  - prom:metrics-endpoint
- - cos-proxy:monitors
  - nrpe:monitors
```


## Release Notes
<!-- A digestable summary of the change in this PR -->
