### PR TITLE
Fix alerts assignment when event is None

### DIFF
--- a/tests/unit/test_relation_monitors.py
+++ b/tests/unit/test_relation_monitors.py
@@ -94,6 +94,6 @@ class TestRelationMonitors(unittest.TestCase):
         rel_id_prom = self.harness.add_relation("downstream-prometheus-scrape", "prom")
         self.harness.add_relation_unit(rel_id_prom, "prom/0")
 
-        # Alert rules are transferred to prometheus over relation data
+        # THEN alert rules are transferred to prometheus over relation data
         app_data = self.harness.get_relation_data(rel_id_prom, "cos-proxy")
         self.assertIn("alert_rules", app_data)

--- a/tests/unit/test_relation_monitors.py
+++ b/tests/unit/test_relation_monitors.py
@@ -81,3 +81,19 @@ class TestRelationMonitors(unittest.TestCase):
             ]
         )
         self.assertEqual(expected, self.mock_enrichment_file.read_text())
+
+    def test_prometheus(self):
+        # GIVEN a post-startup charm
+        self.harness.begin_with_initial_hooks()
+
+        # WHEN "monitors" and "downstream-prometheus-scrape" relations join
+        rel_id_nrpe = self.harness.add_relation("monitors", "nrpe")
+        self.harness.add_relation_unit(rel_id_nrpe, "nrpe/0")
+        self.harness.update_relation_data(rel_id_nrpe, "nrpe/0", self.default_unit_data)
+
+        rel_id_prom = self.harness.add_relation("downstream-prometheus-scrape", "prom")
+        self.harness.add_relation_unit(rel_id_prom, "prom/0")
+
+        # Alert rules are transferred to prometheus over relation data
+        app_data = self.harness.get_relation_data(rel_id_prom, "cos-proxy")
+        self.assertIn("alert_rules", app_data)


### PR DESCRIPTION
## Issue
The nrpe targets changed event hook is sometimes called without an event arg. In such cases we cannot obtain alerts from `event` attributes.

## Solution
Obtain alerts from stored state. This is the same as #94, but follows-up #100.

Fixes #102.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
See newly added utest. Before this change, the utest would fail with the same error reported in #102.

## Release Notes
<!-- A digestable summary of the change in this PR -->
