### PR TITLE
Update stored state after relation data

### DIFF
--- a/tests/unit/test_relation_monitors.py
+++ b/tests/unit/test_relation_monitors.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 from charm import COSProxyCharm
+from ops.model import ActiveStatus
 from ops.testing import Harness
 
 
@@ -97,3 +98,9 @@ class TestRelationMonitors(unittest.TestCase):
         # THEN alert rules are transferred to prometheus over relation data
         app_data = self.harness.get_relation_data(rel_id_prom, "cos-proxy")
         self.assertIn("alert_rules", app_data)
+
+        # AND status is "active"
+        self.assertIsInstance(
+            self.harness.model.unit.status,
+            ActiveStatus,
+        )

--- a/tox.ini
+++ b/tox.ini
@@ -87,7 +87,7 @@ description = Run integration tests
 description = Run scenario tests
 deps =
     pytest
-    ops-scenario >= 5.4
+    ops-scenario == 5.4
     coverage[toml]
     cosl
 commands =


### PR DESCRIPTION
## Issue
Some units are stuck in blocked `Missing one of (Prometheus|target|nrpe) relation(s)`, even though all relations are in fact in place.

## Solution
Set `_stored.have_prometheus = True` only after updating relation data. Related to #89. Addresses #105.

Drive-by fixes:
- Append instead of overwriting "missing relation" status messages.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
### In an existing deployment
```
juju refresh --switch cos-proxy --channel=edge/108 cos-proxy-monitors  # Expires at 2024-02-04T00:00:00Z
```

### In a dev env
Deploy the k8s bundle in a k8s model and the lxd bundle in a lxd model
```
$ juju deploy --trust ./k8s-bundle.yaml  # on k8s model
$ juju deploy ./lxd-bundle.yaml  # on lxd model
```

```yaml
# k8s-bundle.yaml
bundle: kubernetes
applications:
  prom:
    charm: prometheus-k8s
    channel: edge
    revision: 163
    resources:
      prometheus-image: 136
    scale: 1
    trust: true
--- # overlay.yaml
applications:
  prom:
    offers:
      prom:
        endpoints:
        - metrics-endpoint
        - receive-remote-write
        acl:
          admin: admin
```

```yaml
# lxd-bundle.yaml
series: jammy
saas:
  prom:
    url: k8s2:admin/cos.prom
applications:
  cos-proxy:
    charm: ./cos-proxy_ubuntu-20.04-amd64_ubuntu-22.04-amd64.charm
    series: focal
    num_units: 1
  nrpe:
    charm: nrpe
    channel: edge
    revision: 114
  ub:
    charm: ubuntu
    channel: stable
    revision: 24
    series: focal
    num_units: 1
relations:
- - cos-proxy:downstream-prometheus-scrape
  - prom:metrics-endpoint
- - nrpe:monitors
  - cos-proxy:monitors
- - nrpe:general-info
  - ub:juju-info
```

## Release Notes
<!-- A digestable summary of the change in this PR -->
