### PR TITLE
Add keepalive to logstash source

### DIFF
--- a/lib/charms/vector/v0/vector.py
+++ b/lib/charms/vector/v0/vector.py
@@ -84,6 +84,9 @@ sources:
   logstash:
     address: "0.0.0.0:5044"
     type: logstash
+    mode: tcp
+    keepalive:
+      time_secs: 3600
 transforms:
   enrich-nrpe:
     type: remap


### PR DESCRIPTION
## Issue
#112 

## Solution
Add a keepalive to the logstash source so that if it doesn't receive a packet for one hour, it will drop the connection and free the resources.

## Testing Instructions
Mostly the same instructions as described on #112 - Just verify that the connections are dropped.


## Release Notes