### PR TITLE
Variable e was used twice in the same scope

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -390,8 +390,8 @@ class COSProxyCharm(CharmBase):
                     loki_endpoints.append(json.loads(endpoint)["url"])
 
         if loki_endpoints:
-            for e in loki_endpoints:
-                dest = re.sub(r"^(.*?/loki/api/v1)/push$", r"\1/series", e)
+            for endpoint in loki_endpoints:
+                dest = re.sub(r"^(.*?/loki/api/v1)/push$", r"\1/series", endpoint)
                 try:
                     r = request.urlopen(dest)
                     if r.code != 200:


### PR DESCRIPTION
The name "e" was used for two variables in the same scope. Technically it wasn't a bug but could easily become one.

Part of #85