### PR TITLE
Allow hostnames without unit id

### DIFF
--- a/lib/charms/nrpe_exporter/v0/nrpe_exporter.py
+++ b/lib/charms/nrpe_exporter/v0/nrpe_exporter.py
@@ -453,13 +453,9 @@ class NrpeExporterProvider(Object):
 
     def _generate_alert(self, relation, cmd, id, unit) -> dict:
         """Generate an on-the-fly Alert rule."""
-        pattern = r"^(.*?)[-_](\d+)$"
-        if match := re.match(pattern, id.replace("_", "-")):
-            app_name, unit_num = match.groups()
-        else:
-            raise ValueError(f"Invalid unit identifier '{id}': expected a string like 'unit-0'")
+        unit_label = re.sub(r"^(.*?)[-_](\d+)$", r"\1/\2", id.replace("_", "-"))
+        app_label = re.sub(r"^(.*?)[-_]\d+$", r"\1", id.replace("_", "-"))
 
-        unit_label = f"{app_name}/{unit_num}"
         return {
             "alert": "{}NrpeAlert".format("".join([x.title() for x in cmd.split("_")])),
             # Average over 5 minutes considering a 60-second scrape interval
@@ -470,7 +466,7 @@ class NrpeExporterProvider(Object):
             "labels": {
                 "severity": "{{ if eq $value 0.0 -}} info {{- else if eq $value 1.0 -}} warning {{- else if eq $value 2.0 -}} critical {{- else if eq $value 3.0 -}} error {{- end }}",
                 "juju_model": self.model.name,
-                "juju_application": app_name,
+                "juju_application": app_label,
                 "juju_unit": unit_label,
                 "nrpe_application": relation.app.name,
                 "nrpe_unit": unit.name,

--- a/tests/scenario/test_alerts.py
+++ b/tests/scenario/test_alerts.py
@@ -24,7 +24,7 @@ def test_relation(ctx, n_remote_units):
         "monitors",
         remote_app_name="remote",
         remote_units_data={
-            i: {"monitors": yaml.safe_dump(monitors_raw), "target-id": "juju-ubuntu-0"}
+            i: {"monitors": yaml.safe_dump(monitors_raw), "target-id": "hostname-without-unit-id"}
             for i in range(n_remote_units)
         },
     )


### PR DESCRIPTION
## Issue
#117 introduced a regression where hostnames without unit id were assumed to be an error, which breaks compatibility with nrpe running on physical servers and VMs.


## Solution
Restore to the previous "blind" `re.sub` instead of raising with `re.match`.


## Testing
Revision 62 of 'cos-proxy' released to `edge/pr-120`.

Fixes #119.
