### PR TITLE
Fix machine name handling for nrpe_exporter binary

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -22,11 +22,11 @@ parts:
     override-pull: |
       if [ $CRAFT_TARGET_ARCH == "amd64" ]; then
         URI=https://github.com/canonical/nrpe_exporter/releases/latest/download/nrpe_exporter-amd64
+        curl -L $URI -o nrpe_exporter-amd64
       elif [ $CRAFT_TARGET_ARCH == "arm64" ] || [ $CRAFT_TARGET_ARCH == "aarch64" ]; then
         URI=https://github.com/canonical/nrpe_exporter/releases/latest/download/nrpe_exporter-arm64
+        curl -L $URI -o nrpe_exporter-aarch64
       fi
-      
-      curl -L $URI -o nrpe_exporter-aarch64
   vector:
     plugin: dump
     source: .

--- a/src/charm.py
+++ b/src/charm.py
@@ -209,7 +209,16 @@ class COSProxyCharm(CharmBase):
         # Make sure the exporter binary is present with a systemd service
         if not Path("/usr/local/bin/nrpe-exporter").exists():
             arch = platform.machine()
-            arch = "amd64" if arch == "x86_64" else arch
+
+            # Machine names vary. Here we follow Ubuntu's convention of "amd64" and "aarch64".
+            # https://stackoverflow.com/a/45124927/3516684
+            # https://en.wikipedia.org/wiki/Uname
+            if arch in ["x86_64", "amd64"]:
+               arch = "amd64"
+            elif arch in ["aarch64", "arm64", "armv8b", "armv8l"]:
+               arch = "aarch64"
+            # else: keep arch as is
+
             res = "nrpe_exporter-{}".format(arch)
 
             st = Path(res)

--- a/src/charm.py
+++ b/src/charm.py
@@ -214,9 +214,9 @@ class COSProxyCharm(CharmBase):
             # https://stackoverflow.com/a/45124927/3516684
             # https://en.wikipedia.org/wiki/Uname
             if arch in ["x86_64", "amd64"]:
-               arch = "amd64"
+                arch = "amd64"
             elif arch in ["aarch64", "arm64", "armv8b", "armv8l"]:
-               arch = "aarch64"
+                arch = "aarch64"
             # else: keep arch as is
 
             res = "nrpe_exporter-{}".format(arch)


### PR DESCRIPTION
## Issue
Incorrect machine name for nrpe binary.


## Solution
Hard-code machine names.

Fixes #124.


## Testing Instructions
Make sure the follow bundle deploys with no errors:
```yaml
series: jammy
applications:
  cp:
    # Pack from this PR
    charm: ./cos-proxy_ubuntu-20.04-amd64_ubuntu-22.04-amd64.charm
    num_units: 1
  nrpe:
    charm: nrpe
    channel: edge
    revision: 117
  ub:
    charm: ubuntu
    channel: edge
    revision: 24
    num_units: 1
relations:
- - cp:monitors
  - nrpe:monitors
- - nrpe:general-info
  - ub:juju-info
```


## Upgrade Notes
Normal procedure.