### PR TITLE
Fix juju_unit and juju_application labels

### DIFF
--- a/lib/charms/nrpe_exporter/v0/nrpe_exporter.py
+++ b/lib/charms/nrpe_exporter/v0/nrpe_exporter.py
@@ -441,10 +441,14 @@ class NrpeExporterProvider(Object):
                     )
                     id = re.sub(r"^juju[-_]", "", id)
 
+                    nagios_host_context = relation.data[unit].get("nagios_host_context", "")
+
                     alerts.append(self._generate_alert(relation, cmd, id, unit))
 
                     nrpe_endpoints.append(
-                        self._generate_prometheus_job(relation, unit, cmd, exporter_address, id)
+                        self._generate_prometheus_job(
+                            relation, unit, cmd, exporter_address, id, nagios_host_context
+                        )
                     )
             else:
                 logger.debug("No NRPE check is defined.")
@@ -485,12 +489,16 @@ class NrpeExporterProvider(Object):
             },
         }
 
-    def _generate_prometheus_job(self, relation, unit, cmd, exporter_address, id) -> dict:
+    def _generate_prometheus_job(
+        self, relation, unit, cmd, exporter_address, id, nagios_host_context
+    ) -> dict:
         """Generate an on-the-fly Prometheus scrape job."""
         # IP address could be 'target-address' OR 'target_address'
         addr = relation.data[unit].get("target-address", "") or relation.data[unit].get(
             "target_address", ""
         )
+
+        nagios_host_context = nagios_host_context + "-" if nagios_host_context else ""
 
         return {
             "app_name": relation.app.name,
@@ -511,8 +519,21 @@ class NrpeExporterProvider(Object):
                     },
                     {
                         "target_label": "juju_unit",
-                        # Turn sql-foo-0 or redis_bar_1 into sql-foo/0 or redis-bar/1
-                        "replacement": re.sub(r"^(.*?)[-_](\d+)$", r"\1/\2", id.replace("_", "-")),
+                        # Turn nagios-host-context-sql-foo-0 into sql-foo/0
+                        "replacement": re.sub(
+                            r"^(.*?)[-_](\d+)$",
+                            r"\1/\2",
+                            id.replace("_", "-").replace(nagios_host_context, ""),
+                        ),
+                    },
+                    {
+                        "target_label": "juju_application",
+                        # Turn nagios-host-context-sql-foo-0 into sql-foo
+                        "replacement": re.sub(
+                            r"^(.*?)[-_](\d+)$",
+                            r"\1",
+                            id.replace("_", "-").replace(nagios_host_context, ""),
+                        ),
                     },
                 ],
                 "updates": {

--- a/src/charm.py
+++ b/src/charm.py
@@ -130,7 +130,7 @@ class COSProxyCharm(CharmBase):
         self.metrics_aggregator = MetricsEndpointAggregator(self, resolve_addresses=True)
         self.cos_agent = COSAgentProvider(
             self,
-            scrape_configs=self._get_scrape_configs,
+            scrape_configs=self._get_scrape_configs(),
             metrics_rules_dir=RULES_DIR,
             dashboard_dirs=[COS_PROXY_DASHBOARDS_DIR, DASHBOARDS_DIR],
             refresh_events=[

--- a/tests/unit/test_relation_monitors.py
+++ b/tests/unit/test_relation_monitors.py
@@ -97,7 +97,7 @@ class TestRelationMonitors(unittest.TestCase):
 
         # THEN alert rules are transferred to prometheus over relation data
         app_data = self.harness.get_relation_data(rel_id_prom, "cos-proxy")
-        self.assertIn("alert_rules", app_data)
+        self.assertIn("alert_rules", app_data)  # pyright: ignore
 
         # AND status is "active"
         self.assertIsInstance(

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ deps =
     codespell
 commands =
     codespell {[vars]lib_path}
-    codespell . --skip .git --skip .tox --skip build --skip lib --skip venv* --skip .mypy_cache
+    codespell . --skip .git --skip .tox --skip build --skip lib --skip venv* --skip .mypy_cache -L assertIn
     ruff {[vars]all_path}
     black --check --diff {[vars]all_path}
 


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->

This PR fixes #134


## Solution
<!-- A summary of the solution addressing the above issue -->

Based on [the PR](https://github.com/canonical/charm-nrpe/pull/184) created by @dashmage, now we are able to properly add `relabel_configs` for `juju_application` and `juju_unit`



## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

Let's imagine we have the following deployment:

![image](https://github.com/canonical/cos-proxy-operator/assets/939888/1d9e0c47-4e3a-4423-b2d7-55c9070ee329)

With the following config in `nrpe`:

```
juju config nrpe nagios_host_context="bootstack-blue"
```


Once every relation is in place, we can see in Prometheus that `juju_application` and `juju_unit` are ok:


![image](https://github.com/canonical/cos-proxy-operator/assets/939888/27f09fbf-7b25-440e-8c19-43ec54d9f242)
