### PR TITLE
update charm-relation-interfaces to use prometheus_scrape schema that is compatible with pydantic v2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
 git+https://github.com/canonical/operator#egg=ops
-# TODO: Revert this change when the fix lands in charm-relation-interfaces
-# git+https://github.com/canonical/charm-relation-interfaces.git@main
-git+https://github.com/ca-scribner/charm-relation-interfaces.git@ad4bf57a57533426c836a3157673f2230a05e9ea
+git+https://github.com/canonical/charm-relation-interfaces.git@main
 jinja2 < 3
 markupsafe == 2.0.1
 pydantic > 2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 git+https://github.com/canonical/operator#egg=ops
-git+https://github.com/canonical/charm-relation-interfaces.git@main
+# TODO: Revert this change when the fix lands in charm-relation-interfaces
+# git+https://github.com/canonical/charm-relation-interfaces.git@main
+git+https://github.com/ca-scribner/charm-relation-interfaces.git@ad4bf57a57533426c836a3157673f2230a05e9ea
 jinja2 < 3
 markupsafe == 2.0.1
 pydantic > 2

--- a/tests/scenario/helpers.py
+++ b/tests/scenario/helpers.py
@@ -1,0 +1,12 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+from pathlib import Path
+
+import yaml
+
+CHARM_ROOT = Path(__file__).parent.parent.parent
+
+
+def get_charm_meta() -> dict:
+    raw_meta = (CHARM_ROOT / "metadata").with_suffix(".yaml").read_text()
+    return yaml.safe_load(raw_meta)

--- a/tests/scenario/test_charm.py
+++ b/tests/scenario/test_charm.py
@@ -1,0 +1,77 @@
+import json
+
+import scenario
+from charm import COSProxyCharm
+
+from tests.scenario.helpers import get_charm_meta
+
+RELABEL_INSTANCE_CONFIG = {
+    "source_labels": [
+        "juju_model",
+        "juju_model_uuid",
+        "juju_application",
+        "juju_unit",
+    ],
+    "separator": "_",
+    "target_label": "instance",
+    "regex": "(.*)",
+}
+
+
+def test_scrape_jobs_are_forwarded_on_adding_prometheus_then_targets():
+    # Arrange
+    prometheus_scrape_relation = scenario.Relation(
+        "downstream-prometheus-scrape",
+        remote_app_name="cos-prometheus",
+        remote_units_data={
+            0: {},
+        },
+    )
+    prometheus_target_relation = scenario.Relation(
+        "prometheus-target",
+        remote_app_name="target-app",
+        remote_units_data={
+            0: {
+                "hostname": "scrape_target_0",
+                "port": "1234",
+            },
+        },
+    )
+
+    model_name = "testmodel"
+    model_uuid = "ae3c0b14-9c3a-4262-b560-7a6ad7d3642f"
+    model = scenario.Model(model_name, model_uuid)
+
+    ctx = scenario.Context(COSProxyCharm, meta=get_charm_meta())
+    state_in = scenario.State(
+        leader=True,
+        relations=[prometheus_scrape_relation, prometheus_target_relation],
+        model=model,
+    )
+
+    expected_jobs = [
+        {
+            "job_name": f"juju_{model_name}_{model_uuid[:7]}_target-app_prometheus_scrape",
+            "static_configs": [
+                {
+                    "targets": ["scrape_target_0:1234"],
+                    "labels": {
+                        "juju_model": model_name,
+                        "juju_model_uuid": model_uuid,
+                        "juju_application": "target-app",
+                        "juju_unit": "target-app/0",
+                        "host": "scrape_target_0",
+                        "dns_name": "scrape_target_0",
+                    },
+                }
+            ],
+            "relabel_configs": [RELABEL_INSTANCE_CONFIG],
+        }
+    ]
+
+    # Act
+    out = ctx.run(prometheus_target_relation.changed_event, state_in)
+
+    # Assert
+    actual_jobs = json.loads(out.relations[0].local_app_data.get("scrape_jobs", []))
+    assert actual_jobs == expected_jobs

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -201,50 +201,6 @@ class COSProxyCharmTest(unittest.TestCase):
             BlockedStatus("Missing one of (Grafana|dashboard|grafana-agent) relation(s)"),
         )
 
-    def test_scrape_jobs_are_forwarded_on_adding_prometheus_then_targets(self):
-        self.harness.set_leader(True)
-
-        prometheus_rel_id = self.harness.add_relation(
-            "downstream-prometheus-scrape", "cos-prometheus"
-        )
-        self.harness.add_relation_unit(prometheus_rel_id, "cos-prometheus/0")
-
-        target_rel_id = self.harness.add_relation("prometheus-target", "target-app")
-        self.harness.add_relation_unit(target_rel_id, "target-app/0")
-        self.harness.update_relation_data(
-            target_rel_id,
-            "target-app/0",
-            {
-                "hostname": "scrape_target_0",
-                "port": "1234",
-            },
-        )
-
-        prometheus_rel_data = self.harness.get_relation_data(
-            prometheus_rel_id, self.harness.model.app.name
-        )
-        scrape_jobs = json.loads(prometheus_rel_data.get("scrape_jobs", "[]"))
-        expected_jobs = [
-            {
-                "job_name": "juju_testmodel_ae3c0b1_target-app_prometheus_scrape",
-                "static_configs": [
-                    {
-                        "targets": ["scrape_target_0:1234"],
-                        "labels": {
-                            "juju_model": "testmodel",
-                            "juju_model_uuid": "ae3c0b14-9c3a-4262-b560-7a6ad7d3642f",
-                            "juju_application": "target-app",
-                            "juju_unit": "target-app/0",
-                            "host": "scrape_target_0",
-                            "dns_name": "scrape_target_0",
-                        },
-                    }
-                ],
-                "relabel_configs": [RELABEL_INSTANCE_CONFIG],
-            }
-        ]
-        self.assertListEqual(scrape_jobs, expected_jobs)
-
     def test_scrape_jobs_are_forwarded_on_adding_targets_then_prometheus(self):
         self.harness.set_leader(True)
 


### PR DESCRIPTION
## Issue
Closes #140 

## Solution
The prometheus_scrape schema includes an optional field for `metrics_path`.  Pydantic's semantics for how a field is marked as "optional" changed between v1 and v2, resulting in Pydantic v2 erroneously interpreting the `metrics_path` field as required.  [This PR in charm-relation-interfaces](https://github.com/canonical/charm-relation-interfaces/pull/154) updates the schema to use the pydantic v2 way of defining optional attributes.  The current PR updates our dependencies to use this fixed schema.  

Also included here is a conversion of a unit test to scenario in order to reproduce the above issue.  The previous unit test conceptually should have caught this bug, but because the issue occurred when calling `._get_scrape_configs()` (which is only called in `__init__`) unit tests did not reproduce this bug because `Harness` reuses the Charm object for all events (eg: `__init__` is only called once during `harness.begin()`, not on every event like in real Juju).  By refactoring to scenario, we more closely reproduce true Juju behavior and capture the bug.

## Context
see above and #140

## Testing Instructions
The new scenario test was introduced first before the charm was fixed to demonstrate that the test captures the error from #140 - see [this CI run](https://github.com/canonical/cos-proxy-operator/actions/runs/9571665829/job/26389285483?pr=141#step:5:59) that demonstrates this.  This scenario test should be sufficient to demonstrate the fix works, so if the CI is passing on the PR it should be good.

To reproduce entirely manually, see #140 for instructions. 

## Upgrade Notes
No special procedure needed.  Charm should work once refresh to the latest version.