### PR TITLE
Improve COS Proxy deployment documentation

### DIFF
--- a/INTEGRATING.md
+++ b/INTEGRATING.md
@@ -2,6 +2,7 @@
 
 The diagrams below illustrate how to integrate `cos-proxy` with `cos-lite` charms to monitor legacy (LMA) charms. `cos-proxy` serves as an intermediary solution, helping to bridge the gap between legacy charms and modern `cos-lite`. However, it's essential to note that `cos-proxy` is a **transitional** solution, and whenever possible, you should directly use `grafana-agent`. For more information on integrating with `grafana-agent`, refer to the [gagent INTEGRATING documentation](https://github.com/canonical/grafana-agent-operator/blob/main/INTEGRATING.md).
 
+Please refer to the [`juju exported bundles`](tests/manual/topologies/README.md) to verify the deployment of the below topologies in a test environment.
 
 **Important Note**: Applications should not be directly linked to `cos-proxy` via the `juju-info` relation. Instead, they should interact with a charm similar to`telegraf` for metric collection, which is then handled by `cos-proxy`.
 

--- a/INTEGRATING.md
+++ b/INTEGRATING.md
@@ -1,0 +1,104 @@
+## Topology
+
+Below diagrams illustrate how to integrate `cos-proxy` with `cos-lite` charms to monitor legacy (LMA) charms.
+
+### Integration with COS Proxy
+
+In the topology diagrams:
+
+1. **Direct Integration**: The first diagram shows `cos-proxy` directly interacting with offered SAAS relations from `cos-lite`.
+
+
+2. **Over the COS Agent Interface**: The second diagram demonstrates integration via the grafana-agent's `cos-agent` interface, which receives metrics and dashboards configurations from `cos-proxy`. `grafana-agent` then sends remote writes to `Prometheus` and dashboards configuration data to `Grafana` via the offered SAAS relations from `cos-lite`.
+
+**Important Note**: Applications should not be directly linked to `cos-proxy` via the `juju-info` relation. Instead, they should interact with a charm similar to`telegraf` for metric collection, which is then handled by `cos-proxy`.
+
+## Relating directly to cos-proxy
+
+```mermaid
+graph TD
+
+    %% COS Model Subgraph
+    subgraph cos-k8s["COS K8s Model"]
+        direction TB
+        prometheus["Prometheus-k8s"]
+        grafana["Grafana-k8s"]
+    end
+
+
+
+    %% Reactive Model Subgraph
+    subgraph reactive-model["Machine Model"]
+        direction TB
+        ubuntu["Ubuntu"]
+        telegraf["Telegraf"]
+        cos_proxy["COS Proxy"]
+
+
+        %% Ubuntu and Telegraf Relation
+        ubuntu --- |juju-info| telegraf
+
+        %% Telegraf to cos-proxy Connections
+        telegraf --> |prometheus-client| cos_proxy
+        telegraf --> |prometheus-rules| cos_proxy
+        telegraf --> |dashboards| cos_proxy
+
+        %% SAAS Subgraph
+        subgraph SAAS["SAAS"]
+            GSAAS["Grafana"]
+            PSAAS["Prometheus"]
+
+            %% SAAS to COS Model Connections
+            GSAAS --- |grafana-dashboard| grafana
+            PSAAS --- |metrics-endpoint| prometheus
+        end
+
+        %% cos-proxy to SAAS Connections
+        cos_proxy --> |downstream-prometheus-scrape| PSAAS
+        cos_proxy --> |downstream-grafana-dashboard| GSAAS
+
+    end
+```
+
+## Relating over the cos-agent interface
+
+```mermaid
+graph TD
+    %% COS Lite K8s Subgraph
+    subgraph cos-k8s["COS K8s Model"]
+        prometheus["Prometheus"]
+        grafana["Grafana"]
+        
+
+    end
+
+    %% Machine Model Subgraph
+    subgraph reactive-model["Machine Model"]
+        ubuntu["Ubuntu"]
+        telegraf["Telegraf"]
+        cos_proxy["COS Proxy"]
+        grafana-agent["Grafana Agent"]
+
+        %% Connections
+        ubuntu --> |juju_info| telegraf
+        telegraf --> |prometheus_client| cos_proxy
+        telegraf --> |prometheus_rules| cos_proxy
+        telegraf --> |dashboards| cos_proxy
+
+        cos_proxy --> |cos_agent| grafana-agent
+
+        %% cos-proxy to SAAS Connections
+        grafana-agent --> |send-remote-write| PSAAS
+        grafana-agent --> |grafana-cloud-config| GSAAS
+
+        %% SAAS Subgraph
+        subgraph SAAS["SAAS"]
+            GSAAS["Grafana"]
+            PSAAS["Prometheus"]
+
+            %% SAAS to COS Model Connections
+            GSAAS --- |grafana-dashboard| grafana
+            PSAAS --- |metrics-endpoint| prometheus
+        end
+    end
+```

--- a/tests/manual/topologies/README.md
+++ b/tests/manual/topologies/README.md
@@ -1,0 +1,24 @@
+## Background
+Below are a couple of scenarios to test deployment topologies introduced in `INTEGRATING.md`.
+
+
+### Relating directly to cos-proxy
+- Deploy [`cos-lite`](https://charmhub.io/topics/canonical-observability-stack) in a k8s model
+  - Offer `grafana:grafana-dashboard` and `prometheus:metrics-endpoint` endpoints
+- Consume `grafana:grafana-dashboard` and `prometheus:metrics-endpoint` in a newly created lxd model 
+- Deploy [`cos-proxy-SAAS-bundle`](cos-proxy-SAAS-bundle.yaml) in the lxd model created previously.
+
+## Relating over the cos-agent interface
+- Deploy [`cos-lite`](https://charmhub.io/topics/canonical-observability-stack) in a k8s model
+  - Offer `grafana:grafana-dashboard` and `prometheus:receive-remote-write` endpoints
+- Consume `grafana:grafana-dashboard` and `prometheus:metrics-endpoint` in a newly created lxd model 
+- Deploy [`cos-proxy-gagent-bundle`](cos-proxy-gagent-bundle.yaml) in the lxd model created previously.
+
+### Verify
+- Make sure rule files are available in prometheus:
+  - relation data: `juju show-unit prometheus/0`
+  - on disk: `juju ssh --container prometheus prometheus/0 ls /etc/prometheus/rules`
+  - via http api: `curl x.x.x.x:9090/api/v1/rules | jq`
+- Verify that dashboards are available in grafana:
+  - relation data: `juju show-unit grafana/0`
+  - via grafana dashboard: `x.x.x.x/cos-grafana/dashboards`

--- a/tests/manual/topologies/README.md
+++ b/tests/manual/topologies/README.md
@@ -11,7 +11,7 @@ Below are a couple of scenarios to test deployment topologies introduced in `INT
 ## Relating over the cos-agent interface
 - Deploy [`cos-lite`](https://charmhub.io/topics/canonical-observability-stack) in a k8s model
   - Offer `grafana:grafana-dashboard` and `prometheus:receive-remote-write` endpoints
-- Consume `grafana:grafana-dashboard` and `prometheus:metrics-endpoint` in a newly created lxd model 
+- Consume `grafana:grafana-dashboard` and `prometheus:receive-remote-write` in a newly created lxd model 
 - Deploy [`cos-proxy-gagent-bundle`](cos-proxy-gagent-bundle.yaml) in the lxd model created previously.
 
 ### Verify

--- a/tests/manual/topologies/README.md
+++ b/tests/manual/topologies/README.md
@@ -5,14 +5,12 @@ Below are a couple of scenarios to test deployment topologies introduced in `INT
 ### Relating directly to cos-proxy
 - Deploy [`cos-lite`](https://charmhub.io/topics/canonical-observability-stack) in a k8s model
   - Offer `grafana:grafana-dashboard` and `prometheus:metrics-endpoint` endpoints
-- Consume `grafana:grafana-dashboard` and `prometheus:metrics-endpoint` in a newly created lxd model 
-- Deploy [`cos-proxy-SAAS-bundle`](cos-proxy-SAAS-bundle.yaml) in the lxd model created previously.
+- Deploy [`cos-proxy-SAAS-bundle`](cos-proxy-SAAS-bundle.yaml) in a new lxd model.
 
 ## Relating over the cos-agent interface
 - Deploy [`cos-lite`](https://charmhub.io/topics/canonical-observability-stack) in a k8s model
   - Offer `grafana:grafana-dashboard` and `prometheus:receive-remote-write` endpoints
-- Consume `grafana:grafana-dashboard` and `prometheus:receive-remote-write` in a newly created lxd model 
-- Deploy [`cos-proxy-gagent-bundle`](cos-proxy-gagent-bundle.yaml) in the lxd model created previously.
+- Deploy [`cos-proxy-gagent-bundle`](cos-proxy-gagent-bundle.yaml) in a new lxd model.
 
 ### Verify
 - Make sure rule files are available in prometheus:

--- a/tests/manual/topologies/cos-proxy-SAAS-bundle.yaml
+++ b/tests/manual/topologies/cos-proxy-SAAS-bundle.yaml
@@ -1,0 +1,58 @@
+default-base: ubuntu@22.04/stable
+saas:
+  grafana:
+    url: k8s:admin/cos.grafana
+  prometheus:
+    url: k8s:admin/cos.prometheus
+applications:
+  cos-proxy:
+    charm: cos-proxy
+    channel: latest/edge
+    revision: 95
+    num_units: 1
+    to:
+    - "0"
+    constraints: arch=amd64
+  telegraf:
+    charm: telegraf
+    channel: latest/stable
+    revision: 75
+  ubuntu:
+    charm: ubuntu
+    channel: latest/stable
+    revision: 24
+    base: ubuntu@20.04/stable
+    num_units: 3
+    to:
+    - "1"
+    - "2"
+    - "3"
+    constraints: arch=amd64
+    storage:
+      block: loop,100M
+      files: rootfs,100M
+machines:
+  "0":
+    constraints: arch=amd64
+  "1":
+    constraints: arch=amd64
+    base: ubuntu@20.04/stable
+  "2":
+    constraints: arch=amd64
+    base: ubuntu@20.04/stable
+  "3":
+    constraints: arch=amd64
+    base: ubuntu@20.04/stable
+relations:
+- - telegraf:juju-info
+  - ubuntu:juju-info
+- - prometheus:metrics-endpoint
+  - cos-proxy:downstream-prometheus-scrape
+- - telegraf:dashboards
+  - cos-proxy:dashboards
+- - grafana:grafana-dashboard
+  - cos-proxy:downstream-grafana-dashboard
+- - cos-proxy:prometheus-target
+  - telegraf:prometheus-client
+- - cos-proxy:prometheus-rules
+  - telegraf:prometheus-rules

--- a/tests/manual/topologies/cos-proxy-gagent-bundle.yaml
+++ b/tests/manual/topologies/cos-proxy-gagent-bundle.yaml
@@ -1,0 +1,64 @@
+default-base: ubuntu@22.04/stable
+saas:
+  grafana:
+    url: k8s:admin/cos.grafana
+  prometheus:
+    url: k8s:admin/cos.prometheus
+applications:
+  cos-proxy:
+    charm: cos-proxy
+    channel: latest/edge
+    revision: 95
+    num_units: 1
+    to:
+    - "0"
+    constraints: arch=amd64
+  grafana-agent:
+    charm: grafana-agent
+    channel: latest/stable
+    revision: 164
+  telegraf:
+    charm: telegraf
+    channel: latest/stable
+    revision: 75
+  ubuntu:
+    charm: ubuntu
+    channel: latest/stable
+    revision: 24
+    base: ubuntu@20.04/stable
+    num_units: 3
+    to:
+    - "1"
+    - "2"
+    - "3"
+    constraints: arch=amd64
+    storage:
+      block: loop,100M
+      files: rootfs,100M
+machines:
+  "0":
+    constraints: arch=amd64
+  "1":
+    constraints: arch=amd64
+    base: ubuntu@20.04/stable
+  "2":
+    constraints: arch=amd64
+    base: ubuntu@20.04/stable
+  "3":
+    constraints: arch=amd64
+    base: ubuntu@20.04/stable
+relations:
+- - telegraf:juju-info
+  - ubuntu:juju-info
+- - telegraf:dashboards
+  - cos-proxy:dashboards
+- - cos-proxy:prometheus-target
+  - telegraf:prometheus-client
+- - cos-proxy:prometheus-rules
+  - telegraf:prometheus-rules
+- - grafana-agent:grafana-dashboards-provider
+  - grafana:grafana-dashboard
+- - grafana-agent:cos-agent
+  - cos-proxy:cos-agent
+- - grafana-agent:send-remote-write
+  - prometheus:receive-remote-write


### PR DESCRIPTION
## Issue
`cos-proxy` is lacking deployment diagrams, as well as a description of what relations need/should be hooked, and in what manner.

