### PR TITLE
Use a binary PyYAML package

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -16,6 +16,10 @@ parts:
   charm:
     build-packages:
     - "git"
+    charm-binary-python-packages:
+      # If we build pyyaml from source, then we won't have the C-optimized lib.
+      # With the C-optimized lib, serialization in ops is 20x faster.
+      - PyYAML
   nrpe-exporter:
     plugin: dump
     source: .

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -17,7 +17,7 @@ parts:
     build-packages:
     - "git"
     charm-binary-python-packages:
-      # If we build pyyaml from source, then we won't have the C-optimized lib.
+      # Install PyYAML from binary and avoid building it from sources. This way, we can use PyYAML with C-optimized lib.
       # With the C-optimized lib, serialization in ops is 20x faster.
       - PyYAML
   nrpe-exporter:

--- a/tox.ini
+++ b/tox.ini
@@ -33,7 +33,7 @@ deps =
     black
     ruff
 commands =
-    ruff --fix {[vars]all_path}
+    ruff check --fix {[vars]all_path}
     black {[vars]all_path}
 
 [testenv:lint]
@@ -45,7 +45,7 @@ deps =
 commands =
     codespell {[vars]lib_path}
     codespell .
-    ruff {[vars]all_path}
+    ruff check {[vars]all_path}
     black --check --diff {[vars]all_path}
 
 [testenv:static-{charm,lib}]


### PR DESCRIPTION
## Issue
When we build pyyaml from source, we don't get the C-optimized lib.
As a result, ops serialization is slow.

## Solution
Use the binary version.
Serialization is 20x faster.

Addresses #56.


## Context
- https://github.com/pengwyn/charm-relation-test/pull/2
- https://matrix.to/#/!xdClnUGkurzjxqiQcN:ubuntu.com/$6u1oVcoGibWOg7RkIflLFvfqqHLetfCIwksh7gMli9M?via=ubuntu.com&via=matrix.org
