### PR TITLE
Round the result of avg_over_time

### DIFF
--- a/lib/charms/nrpe_exporter/v0/nrpe_exporter.py
+++ b/lib/charms/nrpe_exporter/v0/nrpe_exporter.py
@@ -475,7 +475,9 @@ class NrpeExporterProvider(Object):
         return {
             "alert": "{}NrpeAlert".format("".join([x.title() for x in cmd.split("_")])),
             # Average over 5 minutes considering a 60-second scrape interval
-            "expr": f"avg_over_time(command_status{{juju_unit='{unit_label}',command='{cmd}'}}[15m]) > 1"
+            # We need to "round" so the severity label is always set. This is
+            # necessary for PagerDuty's dynamic notifications.
+            "expr": f"round(avg_over_time(command_status{{juju_unit='{unit_label}',command='{cmd}'}}[15m])) > 1"
             + f" or (absent_over_time(command_status{{juju_unit='{unit_label}',command='{cmd}'}}[10m]) == 1)"
             + f" or (absent_over_time(up{{juju_unit='{unit_label}'}}[10m]) == 1)",
             "for": "0m",


### PR DESCRIPTION
This is so that the severity label is always set. Else PagerDuty's API fails to send the notification when the average is transitioning between integers, and it causes the AlertmanagerNotificationsFailed alert to fire.

Incidentally, it makes no sense to have the result of an NRPE check to be non-integer, so that shakes that confusing bit off too.