### PR TITLE
Add rust to build packages

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -16,7 +16,7 @@ parts:
   charm:
     build-packages:
     - "git"
-    # rustc and cargo required to build tracing lib's dependency pydantic
+    # rustc and cargo required to build pydantic
     - rustc
     - cargo
     charm-binary-python-packages:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -3,7 +3,7 @@ bases:
   - build-on:
     - name: "ubuntu"
       channel: "20.04"
-    run-on:  
+    run-on:
     - name: "ubuntu"
       channel: "20.04"
   - build-on:
@@ -16,6 +16,9 @@ parts:
   charm:
     build-packages:
     - "git"
+    # rustc and cargo required to build tracing lib's dependency pydantic
+    - rustc
+    - cargo
     charm-binary-python-packages:
       # Install PyYAML from binary and avoid building it from sources. This way, we can use PyYAML with C-optimized lib.
       # With the C-optimized lib, serialization in ops is 20x faster.
@@ -26,10 +29,10 @@ parts:
     build-packages:
       - curl
     override-pull: |
-      if [ $CRAFT_TARGET_ARCH == "amd64" ]; then
+      if [ $CRAFT_ARCH_BUILD_FOR == "amd64" ]; then
         URI=https://github.com/canonical/nrpe_exporter/releases/latest/download/nrpe_exporter-amd64
         curl -L $URI -o nrpe_exporter-amd64
-      elif [ $CRAFT_TARGET_ARCH == "arm64" ] || [ $CRAFT_TARGET_ARCH == "aarch64" ]; then
+      elif [ $CRAFT_ARCH_BUILD_FOR == "arm64" ] || [ $CRAFT_ARCH_BUILD_FOR == "aarch64" ]; then
         URI=https://github.com/canonical/nrpe_exporter/releases/latest/download/nrpe_exporter-arm64
         curl -L $URI -o nrpe_exporter-aarch64
       fi
@@ -41,9 +44,9 @@ parts:
       - tar
     override-pull: |
       VERSION=0.36.0
-      if [ $CRAFT_TARGET_ARCH == "amd64" ]; then
+      if [ $CRAFT_ARCH_BUILD_FOR == "amd64" ]; then
         ARCH=x86_64-unknown-linux-musl
-      elif [ $CRAFT_TARGET_ARCH == "arm64" ]; then
+      elif [ $CRAFT_ARCH_BUILD_FOR == "arm64" ]; then
         ARCH=aarch64-unknown-linux-musl
       fi
 


### PR DESCRIPTION
## Issue
#153 [failed](https://github.com/canonical/cos-proxy-operator/actions/runs/10320770813/job/28572368296) to release because of pack issue.

## Solution
Add rust to build-packages, similar to https://github.com/canonical/alertmanager-k8s-operator/pull/281.

Drive-by: address deprecation warning:
```
CRAFT_TARGET_ARCH is deprecated, use CRAFT_ARCH_BUILD_FOR
```