### PR TITLE
Fix mapped severity

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -23,6 +23,7 @@ parts:
       # Install PyYAML from binary and avoid building it from sources. This way, we can use PyYAML with C-optimized lib.
       # With the C-optimized lib, serialization in ops is 20x faster.
       - PyYAML
+      - cryptography
   nrpe-exporter:
     plugin: dump
     source: .

--- a/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/lib/charms/grafana_agent/v0/cos_agent.py
@@ -22,7 +22,7 @@ this charm library.
 Using the `COSAgentProvider` object only requires instantiating it,
 typically in the `__init__` method of your charm (the one which sends telemetry).
 
-The constructor of `COSAgentProvider` has only one required and nine optional parameters:
+The constructor of `COSAgentProvider` has only one required and ten optional parameters:
 
 ```python
     def __init__(
@@ -36,6 +36,7 @@ The constructor of `COSAgentProvider` has only one required and nine optional pa
         log_slots: Optional[List[str]] = None,
         dashboard_dirs: Optional[List[str]] = None,
         refresh_events: Optional[List] = None,
+        tracing_protocols: Optional[List[str]] = None,
         scrape_configs: Optional[Union[List[Dict], Callable]] = None,
     ):
 ```
@@ -64,6 +65,8 @@ The constructor of `COSAgentProvider` has only one required and nine optional pa
 - `dashboard_dirs`: List of directories where the dashboards are stored in the Charmed Operator.
 
 - `refresh_events`: List of events on which to refresh relation data.
+
+- `tracing_protocols`: List of requested tracing protocols that the charm requires to send traces.
 
 - `scrape_configs`: List of standard scrape_configs dicts or a callable that returns the list in
     case the configs need to be generated dynamically. The contents of this list will be merged
@@ -108,6 +111,7 @@ class TelemetryProviderCharm(CharmBase):
             log_slots=["my-app:slot"],
             dashboard_dirs=["./src/dashboards_1", "./src/dashboards_2"],
             refresh_events=["update-status", "upgrade-charm"],
+            tracing_protocols=["otlp_http", "otlp_grpc"],
             scrape_configs=[
                 {
                     "job_name": "custom_job",
@@ -249,7 +253,7 @@ if TYPE_CHECKING:
 
 LIBID = "dc15fa84cef84ce58155fb84f6c6213a"
 LIBAPI = 0
-LIBPATCH = 10
+LIBPATCH = 11
 
 PYDEPS = ["cosl", "pydantic"]
 

--- a/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/lib/charms/grafana_agent/v0/cos_agent.py
@@ -22,7 +22,6 @@ this charm library.
 Using the `COSAgentProvider` object only requires instantiating it,
 typically in the `__init__` method of your charm (the one which sends telemetry).
 
-The constructor of `COSAgentProvider` has only one required and ten optional parameters:
 
 ```python
     def __init__(
@@ -253,7 +252,7 @@ if TYPE_CHECKING:
 
 LIBID = "dc15fa84cef84ce58155fb84f6c6213a"
 LIBAPI = 0
-LIBPATCH = 11
+LIBPATCH = 12
 
 PYDEPS = ["cosl", "pydantic"]
 

--- a/lib/charms/nrpe_exporter/v0/nrpe_exporter.py
+++ b/lib/charms/nrpe_exporter/v0/nrpe_exporter.py
@@ -477,9 +477,11 @@ class NrpeExporterProvider(Object):
             # Average over 5 minutes considering a 60-second scrape interval
             # We need to "round" so the severity label is always set. This is
             # necessary for PagerDuty's dynamic notifications.
+            #
+            # We multiply the `absent_over_time` by 2 so the value is mapped to a critical severity.
             "expr": f"round(avg_over_time(command_status{{juju_unit='{unit_label}',command='{cmd}'}}[15m])) > 1"
-            + f" or (absent_over_time(command_status{{juju_unit='{unit_label}',command='{cmd}'}}[10m]) == 1)"
-            + f" or (absent_over_time(up{{juju_unit='{unit_label}'}}[10m]) == 1)",
+            + f" or ((absent_over_time(command_status{{juju_unit='{unit_label}',command='{cmd}'}}[10m]) == 1))*2"
+            + f" or ((absent_over_time(up{{juju_unit='{unit_label}'}}[10m]) == 1))*2",
             "for": "0m",
             "labels": {
                 "severity": "{{ if eq $value 0.0 -}} info {{- else if eq $value 1.0 -}} warning {{- else if eq $value 2.0 -}} critical {{- else if eq $value 3.0 -}} error {{- end }}",

--- a/lib/charms/nrpe_exporter/v0/nrpe_exporter.py
+++ b/lib/charms/nrpe_exporter/v0/nrpe_exporter.py
@@ -50,7 +50,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 7
+LIBPATCH = 8
 
 
 logger = logging.getLogger(__name__)

--- a/lib/charms/operator_libs_linux/v0/apt.py
+++ b/lib/charms/operator_libs_linux/v0/apt.py
@@ -122,7 +122,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 14
 
 
 VALID_SOURCE_TYPES = ("deb", "deb-src")
@@ -837,7 +837,7 @@ def remove_package(
 
 def update() -> None:
     """Update the apt cache via `apt-get update`."""
-    subprocess.run(["apt-get", "update"], capture_output=True, check=True)
+    subprocess.run(["apt-get", "update", "--error-on=any"], capture_output=True, check=True)
 
 
 def import_key(key: str) -> str:

--- a/tests/interface/conftest.py
+++ b/tests/interface/conftest.py
@@ -3,8 +3,9 @@
 # from unittest.mock import patch
 
 import pytest
-from charm import COSProxyCharm
 from interface_tester import InterfaceTester
+
+from charm import COSProxyCharm
 
 
 @pytest.fixture

--- a/tests/scenario/test_alerts.py
+++ b/tests/scenario/test_alerts.py
@@ -1,10 +1,11 @@
+from dataclasses import replace
 from itertools import chain
 from unittest.mock import MagicMock, patch
 
 import pytest
 import yaml
 from charms.nrpe_exporter.v0.nrpe_exporter import NrpeTargetsChangedEvent
-from scenario import Context, Network, Relation, State
+from scenario import Address, BindAddress, Context, Network, Relation, State, StoredState
 
 from charm import COSProxyCharm
 
@@ -15,7 +16,7 @@ def ctx():
 
 
 def test_base(ctx):
-    ctx.run("start", State())
+    ctx.run(ctx.on.start(), State())
 
 
 @pytest.mark.parametrize("n_remote_units", (1, 5, 10))
@@ -29,10 +30,16 @@ def test_relation(ctx, n_remote_units):
             for i in range(n_remote_units)
         },
     )
-    state_in = State(leader=True, relations=[monitors], networks={"monitors": Network.default()})
+    network = Network("monitors", [BindAddress([Address("192.0.2.1")])])
+
+    stored_state = StoredState(owner_path="COSProxyCharm", name="_stored", content={})
+
+    state_in = State(
+        leader=True, relations=[monitors], networks={network}, stored_states={stored_state}
+    )
 
     with patch("charm.COSProxyCharm._modify_enrichment_file", new=MagicMock()) as f:
-        state_out = ctx.run(monitors.changed_event, state_in)
+        state_out = ctx.run(ctx.on.relation_changed(relation=monitors), state_in)
 
     assert f.called
     known_remote_units = set(chain(*(e["target"].keys() for e in f.call_args[1]["endpoints"])))
@@ -41,13 +48,13 @@ def test_relation(ctx, n_remote_units):
 
     assert isinstance(ctx.emitted_events[1], NrpeTargetsChangedEvent)
 
-    _ = state_out.stored_state
+    _ = state_out.stored_states
 
     # simulate pod churn: wipe stored state
-    state_after_pod_churn = state_out.replace(stored_state=[])
+    state_after_pod_churn = replace(state_out, stored_states=[])
 
     with patch("charm.COSProxyCharm._modify_enrichment_file", new=MagicMock()) as f2:
-        state_out = ctx.run(monitors.changed_event, state_after_pod_churn)
+        state_out = ctx.run(ctx.on.relation_changed(monitors), state_after_pod_churn)
     known_remote_units2 = set(chain(*(e["target"].keys() for e in f2.call_args[1]["endpoints"])))
 
     assert known_remote_units == known_remote_units2
@@ -56,7 +63,7 @@ def test_relation(ctx, n_remote_units):
     state_after_fs_wipe = state_out
 
     with patch.object(COSProxyCharm, "_modify_enrichment_file", wraps=MagicMock) as f3:
-        with ctx.manager(monitors.changed_event, state_after_fs_wipe) as mgr:
+        with ctx(ctx.on.relation_changed(relation=monitors), state_after_fs_wipe) as mgr:
             mgr.run()
             call_args = f3.call_args[1].copy()
             mgr.charm._modify_enrichment_file(call_args)

--- a/tests/scenario/test_alerts.py
+++ b/tests/scenario/test_alerts.py
@@ -3,9 +3,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import yaml
-from charm import COSProxyCharm
 from charms.nrpe_exporter.v0.nrpe_exporter import NrpeTargetsChangedEvent
 from scenario import Context, Network, Relation, State
+
+from charm import COSProxyCharm
 
 
 @pytest.fixture

--- a/tests/scenario/test_alerts.py
+++ b/tests/scenario/test_alerts.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import yaml
 from charms.nrpe_exporter.v0.nrpe_exporter import NrpeTargetsChangedEvent
-from scenario import Address, BindAddress, Context, Network, Relation, State, StoredState
+from scenario import Context, Relation, State, StoredState
 
 from charm import COSProxyCharm
 
@@ -30,13 +30,9 @@ def test_relation(ctx, n_remote_units):
             for i in range(n_remote_units)
         },
     )
-    network = Network("monitors", [BindAddress([Address("192.0.2.1")])])
 
     stored_state = StoredState(owner_path="COSProxyCharm", name="_stored", content={})
-
-    state_in = State(
-        leader=True, relations=[monitors], networks={network}, stored_states={stored_state}
-    )
+    state_in = State(leader=True, relations=[monitors], stored_states={stored_state})
 
     with patch("charm.COSProxyCharm._modify_enrichment_file", new=MagicMock()) as f:
         state_out = ctx.run(ctx.on.relation_changed(relation=monitors), state_in)

--- a/tests/scenario/test_charm.py
+++ b/tests/scenario/test_charm.py
@@ -40,7 +40,7 @@ def test_scrape_jobs_are_forwarded_on_adding_prometheus_then_targets():
 
     model_name = "testmodel"
     model_uuid = "ae3c0b14-9c3a-4262-b560-7a6ad7d3642f"
-    model = scenario.Model(model_name, model_uuid)
+    model = scenario.Model(name=model_name, uuid=model_uuid)
 
     ctx = scenario.Context(COSProxyCharm, meta=get_charm_meta())
     state_in = scenario.State(
@@ -70,8 +70,8 @@ def test_scrape_jobs_are_forwarded_on_adding_prometheus_then_targets():
     ]
 
     # Act
-    out = ctx.run(prometheus_target_relation.changed_event, state_in)
-
+    out = ctx.run(ctx.on.relation_changed(relation=prometheus_target_relation), state=state_in)
+    relation = next(iter(out.relations))
     # Assert
-    actual_jobs = json.loads(out.relations[0].local_app_data.get("scrape_jobs", []))
+    actual_jobs = json.loads(relation.local_app_data.get("scrape_jobs", []))
     assert actual_jobs == expected_jobs

--- a/tests/scenario/test_charm.py
+++ b/tests/scenario/test_charm.py
@@ -1,8 +1,8 @@
 import json
 
 import scenario
-from charm import COSProxyCharm
 
+from charm import COSProxyCharm
 from tests.scenario.helpers import get_charm_meta
 
 RELABEL_INSTANCE_CONFIG = {

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -22,9 +22,10 @@ import unittest
 import uuid
 from unittest.mock import patch
 
-from charm import COSProxyCharm
 from ops.model import ActiveStatus, BlockedStatus
 from ops.testing import Harness
+
+from charm import COSProxyCharm
 
 ALERT_RULE_1 = """- alert: CPU_Usage
   expr: cpu_usage_idle{is_container!=\"True\", group=\"promoagents-juju\"} < 10

--- a/tests/unit/test_relation_monitors.py
+++ b/tests/unit/test_relation_monitors.py
@@ -4,9 +4,10 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-from charm import COSProxyCharm
 from ops.model import ActiveStatus
 from ops.testing import Harness
+
+from charm import COSProxyCharm
 
 NAGIOS_HOST_CONTEXT = "ubuntu"
 POD_NAME = "ubuntu-is-amazing-0"

--- a/tox.ini
+++ b/tox.ini
@@ -87,7 +87,7 @@ description = Run integration tests
 description = Run scenario tests
 deps =
     pytest
-    ops-scenario>=6
+    ops-scenario
     coverage[toml]
     cosl
     -r{toxinidir}/requirements.txt
@@ -101,7 +101,7 @@ commands =
 description = Run interface tests
 deps =
     pytest
-    ops-scenario>=6
+    ops-scenario
     pytest-interface-tester
     cosl
     -r{toxinidir}/requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -87,7 +87,7 @@ description = Run integration tests
 description = Run scenario tests
 deps =
     pytest
-    ops-scenario
+    ops[testing]
     coverage[toml]
     cosl
     -r{toxinidir}/requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -51,7 +51,7 @@ commands =
 [testenv:static-{charm,lib}]
 description = Run static analysis checks
 deps =
-    pyright==1.1.381 # https://github.com/microsoft/pyright/issues/9539
+    pyright==1.1.381 # https://github.com/canonical/cos-proxy-operator/issues/165
     charm: -r{toxinidir}/requirements.txt
     lib: ops
     charm: responses==0.20.0

--- a/tox.ini
+++ b/tox.ini
@@ -51,7 +51,7 @@ commands =
 [testenv:static-{charm,lib}]
 description = Run static analysis checks
 deps =
-    pyright
+    pyright==1.1.381 # https://github.com/microsoft/pyright/issues/9539
     charm: -r{toxinidir}/requirements.txt
     lib: ops
     charm: responses==0.20.0


### PR DESCRIPTION
This PR fixes: https://github.com/canonical/cos-proxy-operator/issues/146

We multiply the value  by 2 so the severity is mapped to a critical

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

1. Create a k8s model and deploy `cos-lite` in it
2. Offer the `prometheus-scrape` interface: `juju offer prometheus:metrics-endpoint prometheus-scrape`
3. Create a machine model
4. Consume the `prometheus-scrape` offer: `juju consume microk8s:admin/cos.prometheus-scrape`
6.  Deploy this bundle:

```yaml
default-base: ubuntu@22.04/stable
saas:
  grafana-dashboards:
    url: microk8s:admin/cos.grafana-dashboards
  loki-logging:
    url: microk8s:admin/cos.loki-logging
  prometheus-receive-remote-write:
    url: microk8s:admin/cos.prometheus-receive-remote-write
  prometheus-scrape:
    url: microk8s:admin/cos.prometheus-scrape
applications:
  cos-proxy:
    charm: local:cos-proxy-0
    num_units: 1
    to:
    - "2"
    constraints: arch=amd64
  nrpe:
    charm: nrpe
    channel: latest/edge
    revision: 139
  ubu22:
    charm: ubuntu
    channel: latest/stable
    revision: 25
    num_units: 1
    to:
    - "3"
    constraints: arch=amd64
    storage:
      block: loop,100M
      files: rootfs,100M
machines:
  "2":
    constraints: arch=amd64
  "3":
    constraints: arch=amd64
relations:
- - cos-proxy:monitors
  - nrpe:monitors
- - cos-proxy:downstream-logging
  - loki-logging:logging
- - ubu22:juju-info
  - nrpe:general-info
- - cos-proxy:downstream-prometheus-scrape
  - prometheus-scrape:metrics-endpoint
```

7. Stop the nrpe-exporter service: `juju ssh cos-proxy/1 sudo systemctl stop nrpe-exporter`
8. Wait 15 minutes and check in Alertmanager:

![image](https://github.com/user-attachments/assets/06aa9970-ef58-49b4-9299-2f08833d601e)

