### PR TITLE
Redirect the issue sync (do not merge)

### DIFF
--- a/.github/.jira_sync_config.yaml
+++ b/.github/.jira_sync_config.yaml
@@ -1,5 +1,5 @@
 settings:
-  jira_project_key: "OPENG"
+  jira_project_key: "OBC"
   status_mapping:
     opened: Untriaged
     closed: done
@@ -7,7 +7,6 @@ settings:
     
   components:
     - cos-proxy
-    - team-core
       
   add_gh_comment: false
   sync_description: false


### PR DESCRIPTION
Redirect the issue sync to the new core jira project.  
I will merge this in all repos at the same time, so leave it open for now.