### PR TITLE
Removing duplicated data when creating prometheus data

### DIFF
--- a/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
+++ b/lib/charms/prometheus_k8s/v0/prometheus_scrape.py
@@ -1881,7 +1881,9 @@ class MetricsEndpointAggregator(Object):
         # Add alert rules from file
         if self.path_to_own_alert_rules:
             alert_rules.add_path(self.path_to_own_alert_rules, recursive=True)
-        # Add generic alert rules
+        # Remove duplicated data and add generic alert rules
+        identifier = self.topology.identifier.replace("-", "_")
+        groups = [g for g in groups if not g["name"].startswith(identifier)]
         alert_rules.add(
             generic_alert_groups.application_rules, group_name_prefix=self.topology.identifier
         )


### PR DESCRIPTION
For now, nrpe alert is not created as there is duplicated issue

default_xxxxxxxx_cos_proxy_HostHealth_alert

when running _set_prometheus_data, removing duplicated one helps.

WIP : unit test, removing alert in relation data as well.

## Issue
<!-- What issue is this PR trying to solve? -->
#194 

## Solution
<!-- A summary of the solution addressing the above issue -->
removing duplicated one before adding it. ( in case there are many duplicated alerts )

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->


## Testing Instructions
<!-- What steps need to be taken to test this PR? -->


## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
