### PR TITLE
refactor: INTEGRATING.md to include NRPE relation

### DIFF
--- a/INTEGRATING.md
+++ b/INTEGRATING.md
@@ -1,6 +1,6 @@
 ## Background
 
-The diagrams below illustrate how to integrate `cos-proxy` with `cos-lite` charms to monitor legacy (LMA) charms. `cos-proxy` serves as an intermediary solution, helping to bridge the gap between legacy charms and modern `cos-lite`. However, it's essential to note that `cos-proxy` is a **transitional** solution, and whenever possible, you should directly use `grafana-agent`. For more information on integrating with `grafana-agent`, refer to the [gagent INTEGRATING documentation](https://github.com/canonical/grafana-agent-operator/blob/main/INTEGRATING.md).
+The diagrams below illustrate how to integrate `cos-proxy` with `cos-lite` charms to monitor legacy (LMA) charms. `cos-proxy` serves as an intermediary solution, helping to bridge the gap between legacy charms and modern `cos-lite`. However, it's essential to note that `cos-proxy` is a **transitional** solution, and whenever possible, you should directly use `grafana-agent`. For more information on integrating with `grafana-agent` (or `otelcol`), refer to the [gagent INTEGRATING documentation](https://github.com/canonical/grafana-agent-operator/blob/main/INTEGRATING.md).
 
 Please refer to the [`juju exported bundles`](tests/manual/topologies/README.md) to verify the deployment of the below topologies in a test environment.
 

--- a/INTEGRATING.md
+++ b/INTEGRATING.md
@@ -17,46 +17,51 @@ If your charm does not support the `cos-agent` interface, consider relating `cos
 ```mermaid
 graph TD
 
-    %% COS Model Subgraph
-    subgraph cos-k8s["COS K8s Model"]
-        direction TB
-        prometheus["prometheus-k8s"]
-        grafana["grafana-k8s"]
-    end
-
-
-
-    %% Reactive Model Subgraph
-    subgraph reactive-model["Machine Model"]
-        direction TB
-        ubuntu["ubuntu"]
-        telegraf["telegraf"]
-        cos_proxy["cos-proxy"]
-
-
-        %% Ubuntu and Telegraf Relation
-        ubuntu --- |juju-info| telegraf
-
-        %% Telegraf to cos-proxy Connections
-        telegraf --> |prometheus-client| cos_proxy
-        telegraf --> |prometheus-rules| cos_proxy
-        telegraf --> |dashboards| cos_proxy
-
+    %% Machine Model Subgraph
+    subgraph machine-model["Machine model"]
+        direction TD
         %% SAAS Subgraph
         subgraph SAAS["SAAS"]
             GSAAS["grafana-k8s"]
             PSAAS["prometheus-k8s"]
-
-            %% SAAS to COS Model Connections
-            GSAAS --- |grafana-dashboard| grafana
-            PSAAS --- |metrics-endpoint| prometheus
         end
 
-        %% cos-proxy to SAAS Connections
-        cos_proxy --> |downstream-prometheus-scrape| PSAAS
-        cos_proxy --> |downstream-grafana-dashboard| GSAAS
-
+        subgraph machine-1["Machine 1"]
+            ubuntu["ubuntu/0"]
+            
+            subgraph subordinates-1["Subordinates"]
+                nrpe["nrpe/0"]
+                telegraf["telegraf/0"]
+            end
+        end
+    
+        %% cos-proxy Subgraph
+        subgraph machine-0["Machine 0"]
+            cos_proxy["cos-proxy"]
+        end
     end
+
+    %% COS Lite K8s Subgraph
+    subgraph cos-k8s["COS K8s Model"]
+        prometheus["prometheus-k8s"]
+        grafana["grafana-k8s"]
+    end
+
+    %% Connections
+    ubuntu --- |general-info| nrpe
+    ubuntu --- |juju-info| telegraf
+    telegraf --- |prometheus_client| cos_proxy
+    telegraf --- |prometheus_rules| cos_proxy
+    telegraf --- |dashboards| cos_proxy
+    nrpe --- |monitors| cos_proxy
+
+    %% cos-proxy to SAAS Connections
+    cos_proxy --- |downstream-prometheus-scrape| PSAAS
+    cos_proxy --- |downstream-grafana-dashboard| GSAAS
+
+    %% SAAS to COS Model Connections
+    GSAAS --- |grafana-dashboard| grafana
+    PSAAS --- |metrics-endpoint| prometheus
 ```
 
 ## Relating over the cos-agent interface
@@ -66,41 +71,58 @@ In this topology, integration is achieved via the `grafana-agent`'s `cos-agent` 
 
 ```mermaid
 graph TD
-    %% COS Lite K8s Subgraph
-    subgraph cos-k8s["COS K8s Model"]
-        prometheus["prometheus-k8s"]
-        grafana["grafana-k8s"]
-        
-
-    end
 
     %% Machine Model Subgraph
-    subgraph reactive-model["Machine Model"]
-        ubuntu["ubuntu"]
-        telegraf["telegraf"]
-        cos_proxy["cos-proxy"]
-        grafana-agent["grafana-agent"]
-
-        %% Connections
-        ubuntu --> |juju_info| telegraf
-        telegraf --> |prometheus_client| cos_proxy
-        telegraf --> |prometheus_rules| cos_proxy
-        telegraf --> |dashboards| cos_proxy
-
-        cos_proxy --> |cos_agent| grafana-agent
-
-        %% cos-proxy to SAAS Connections
-        grafana-agent --> |send-remote-write| PSAAS
-        grafana-agent --> |grafana-dashboards-provider| GSAAS
-
+    subgraph machine-model["Machine model"]
+        direction TD
         %% SAAS Subgraph
         subgraph SAAS["SAAS"]
             GSAAS["grafana-k8s"]
             PSAAS["prometheus-k8s"]
+        end
 
-            %% SAAS to COS Model Connections
-            GSAAS --- |grafana-dashboard| grafana
-            PSAAS --- |receive-remote-write| prometheus
+        subgraph machine-1["Machine 1"]
+            ubuntu["ubuntu/0"]
+            
+            subgraph subordinates-1["Subordinates"]
+                nrpe["nrpe/0"]
+                telegraf["telegraf/0"]
+            end
+        end
+    
+        %% cos-proxy Subgraph
+        subgraph machine-0["Machine 0"]
+            cos_proxy["cos-proxy"]
+
+            subgraph subordinates-0["Subordinates"]
+                direction LR
+                grafana-agent["otelcol
+                (or grafana-agent)"]
+            end
         end
     end
+
+    %% COS Lite K8s Subgraph
+    subgraph cos-k8s["COS K8s Model"]
+        prometheus["prometheus-k8s"]
+        grafana["grafana-k8s"]
+    end
+
+    %% Connections
+    ubuntu --- |general-info| nrpe
+    ubuntu --- |juju-info| telegraf
+    telegraf --- |prometheus_client| cos_proxy
+    telegraf --- |prometheus_rules| cos_proxy
+    telegraf --- |dashboards| cos_proxy
+    nrpe --- |monitors| cos_proxy
+
+    cos_proxy --- |cos_agent| grafana-agent
+
+    %% cos-proxy to SAAS Connections
+    grafana-agent --- |send-remote-write| PSAAS
+    grafana-agent --- |grafana-dashboards-provider| GSAAS
+
+    %% SAAS to COS Model Connections
+    GSAAS --- |grafana-dashboard| grafana
+    PSAAS --- |receive-remote-write| prometheus
 ```

--- a/INTEGRATING.md
+++ b/INTEGRATING.md
@@ -66,7 +66,7 @@ graph TD
 
 ## Relating over the cos-agent interface
 
-In this topology, integration is achieved via the `grafana-agent`'s `cos-agent` interface. Here, `cos-proxy` sends metrics and dashboard configurations to `grafana-agent`, which then forwards these to `Prometheus` and `Grafana` via the offered SAAS relations from `cos-lite`.
+In this topology, integration is achieved via the `oltelcol` (or `grafana-agent`) `cos-agent` interface. Here, `cos-proxy` sends metrics and dashboard configurations to `grafana-agent`, which then forwards these to `Prometheus` and `Grafana` via the offered SAAS relations from `cos-lite`.
 
 
 ```mermaid


### PR DESCRIPTION
## Issue
<!-- What issue is this PR trying to solve? -->
A user was confused about why they were not seeing metrics for a certain VM-model app in COS after following our INTEGRATING.md literally. They did not know they also needed an `nrpe` application and relations.

## Solution
<!-- A summary of the solution addressing the above issue -->
Improve the docs to include this info in the mermaid diagrams.

## Testing
```mermaid
graph TD

    %% Machine Model Subgraph
    subgraph machine-model["Machine model"]
        direction TD
        %% SAAS Subgraph
        subgraph SAAS["SAAS"]
            GSAAS["grafana-k8s"]
            PSAAS["prometheus-k8s"]
        end

        subgraph machine-1["Machine 1"]
            ubuntu["ubuntu/0"]
            
            subgraph subordinates-1["Subordinates"]
                nrpe["nrpe/0"]
                telegraf["telegraf/0"]
            end
        end
    
        %% cos-proxy Subgraph
        subgraph machine-0["Machine 0"]
            cos_proxy["cos-proxy"]
        end
    end

    %% COS Lite K8s Subgraph
    subgraph cos-k8s["COS K8s Model"]
        prometheus["prometheus-k8s"]
        grafana["grafana-k8s"]
    end

    %% Connections
    ubuntu --- |general-info| nrpe
    ubuntu --- |juju-info| telegraf
    telegraf --- |prometheus_client| cos_proxy
    telegraf --- |prometheus_rules| cos_proxy
    telegraf --- |dashboards| cos_proxy
    nrpe --- |monitors| cos_proxy

    %% cos-proxy to SAAS Connections
    cos_proxy --- |downstream-prometheus-scrape| PSAAS
    cos_proxy --- |downstream-grafana-dashboard| GSAAS

    %% SAAS to COS Model Connections
    GSAAS --- |grafana-dashboard| grafana
    PSAAS --- |metrics-endpoint| prometheus
```

```mermaid
graph TD

    %% Machine Model Subgraph
    subgraph machine-model["Machine model"]
        direction TD
        %% SAAS Subgraph
        subgraph SAAS["SAAS"]
            GSAAS["grafana-k8s"]
            PSAAS["prometheus-k8s"]
        end

        subgraph machine-1["Machine 1"]
            ubuntu["ubuntu/0"]
            
            subgraph subordinates-1["Subordinates"]
                nrpe["nrpe/0"]
                telegraf["telegraf/0"]
            end
        end
    
        %% cos-proxy Subgraph
        subgraph machine-0["Machine 0"]
            cos_proxy["cos-proxy"]

            subgraph subordinates-0["Subordinates"]
                direction LR
                grafana-agent["otelcol
                (or grafana-agent)"]
            end
        end
    end

    %% COS Lite K8s Subgraph
    subgraph cos-k8s["COS K8s Model"]
        prometheus["prometheus-k8s"]
        grafana["grafana-k8s"]
    end

    %% Connections
    ubuntu --- |general-info| nrpe
    ubuntu --- |juju-info| telegraf
    telegraf --- |prometheus_client| cos_proxy
    telegraf --- |prometheus_rules| cos_proxy
    telegraf --- |dashboards| cos_proxy
    nrpe --- |monitors| cos_proxy

    cos_proxy --- |cos_agent| grafana-agent

    %% cos-proxy to SAAS Connections
    grafana-agent --- |send-remote-write| PSAAS
    grafana-agent --- |grafana-dashboards-provider| GSAAS

    %% SAAS to COS Model Connections
    GSAAS --- |grafana-dashboard| grafana
    PSAAS --- |receive-remote-write| prometheus
```