### PR TITLE
ci: add explicit workflow permissions for CodeQL and release

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -7,6 +7,13 @@ on:
       - main
       - track/**
 
+permissions:
+  # Required for CodeQL security scanning
+  security-events: write
+  # Required for private repositories
+  actions: read
+  contents: read
+
 jobs:
   pull-request:
     name: PR

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,14 @@ on:
       - main
       - track/**
 
+permissions:
+  # Required for CodeQL security scanning
+  security-events: write
+  # Required for private repositories
+  actions: read
+  # Write permission needed for the reusable workflow to push git tags
+  contents: write
+
 jobs:
   release:
     uses: canonical/observability/.github/workflows/charm-release.yaml@v1


### PR DESCRIPTION
## Summary

Add explicit permissions block to workflows calling central CI from canonical/observability.

Required due to org-level GitHub Actions permission changes (default changed from read-write to read). The CodeQL analysis in the reusable workflow requires security-events: write permission, and the release workflow needs contents: write to push git tags.

## Changes

- Added `permissions:` block to `.github/workflows/pull-request.yaml`
- Added `permissions:` block to `.github/workflows/release.yaml` (with `contents: write` for tagging)