### PR TITLE
perf: reduce time complexity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 .idea/
 venv/
+.venv/
 build/
 *.charm
+.benchmark/
 
 .coverage
 __pycache__/

--- a/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/lib/charms/grafana_agent/v0/cos_agent.py
@@ -332,13 +332,6 @@ class AmbiguousRelationUsageError(TracingError):
     """Raised when one wrongly assumes that there can only be one relation on an endpoint."""
 
 
-def _model_json(model: pydantic.BaseModel, **kwargs) -> str:
-    """Serialize a pydantic model without warning on pydantic v2."""
-    if hasattr(model, "model_dump_json"):
-        return model.model_dump_json(**kwargs)
-    return model.json(**kwargs)
-
-
 # TODO we want to eventually use `DatabagModel` from cosl but it likely needs a move to common package first
 if int(pydantic.version.VERSION.split(".")[0]) < 2:  # type: ignore
 
@@ -394,7 +387,7 @@ if int(pydantic.version.VERSION.split(".")[0]) < 2:  # type: ignore
                 databag = {}
 
             if self._NEST_UNDER:
-                databag[self._NEST_UNDER] = _model_json(self, by_alias=True)
+                databag[self._NEST_UNDER] = self.json(by_alias=True)
                 return databag
 
             dct = self.dict()
@@ -694,7 +687,7 @@ class COSAgentProvider(Object):
                         log_slots=self._log_slots,
                         tracing_protocols=self._tracing_protocols,
                     )
-                    relation.data[self._charm.unit][data.KEY] = _model_json(data)
+                    relation.data[self._charm.unit][data.KEY] = data.json()
                 except (
                     pydantic.ValidationError,
                     json.decoder.JSONDecodeError,
@@ -1004,7 +997,7 @@ class COSAgentRequirer(Object):
         )
         self.peer_relation.data[self._charm.unit][
             f"{CosAgentPeersUnitData.KEY}-{event.unit.name}"
-        ] = _model_json(data)
+        ] = data.json()
 
         self.on.data_changed.emit()  # pyright: ignore
 
@@ -1053,7 +1046,7 @@ class COSAgentRequirer(Object):
         )
         self.peer_relation.data[self._charm.unit][
             f"{CosAgentPeersUnitData.KEY}-{event.unit.name}"
-        ] = _model_json(data)
+        ] = data.json()
 
         # We can't easily tell if the data that was changed is limited to only the data
         # that goes into peer relation (in which case, if this is not a leader unit, we wouldn't

--- a/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/lib/charms/grafana_agent/v0/cos_agent.py
@@ -332,6 +332,13 @@ class AmbiguousRelationUsageError(TracingError):
     """Raised when one wrongly assumes that there can only be one relation on an endpoint."""
 
 
+def _model_json(model: pydantic.BaseModel, **kwargs) -> str:
+    """Serialize a pydantic model without warning on pydantic v2."""
+    if hasattr(model, "model_dump_json"):
+        return model.model_dump_json(**kwargs)
+    return model.json(**kwargs)
+
+
 # TODO we want to eventually use `DatabagModel` from cosl but it likely needs a move to common package first
 if int(pydantic.version.VERSION.split(".")[0]) < 2:  # type: ignore
 
@@ -387,7 +394,7 @@ if int(pydantic.version.VERSION.split(".")[0]) < 2:  # type: ignore
                 databag = {}
 
             if self._NEST_UNDER:
-                databag[self._NEST_UNDER] = self.json(by_alias=True)
+                databag[self._NEST_UNDER] = _model_json(self, by_alias=True)
                 return databag
 
             dct = self.dict()
@@ -687,7 +694,7 @@ class COSAgentProvider(Object):
                         log_slots=self._log_slots,
                         tracing_protocols=self._tracing_protocols,
                     )
-                    relation.data[self._charm.unit][data.KEY] = data.json()
+                    relation.data[self._charm.unit][data.KEY] = _model_json(data)
                 except (
                     pydantic.ValidationError,
                     json.decoder.JSONDecodeError,
@@ -997,7 +1004,7 @@ class COSAgentRequirer(Object):
         )
         self.peer_relation.data[self._charm.unit][
             f"{CosAgentPeersUnitData.KEY}-{event.unit.name}"
-        ] = data.json()
+        ] = _model_json(data)
 
         self.on.data_changed.emit()  # pyright: ignore
 
@@ -1046,7 +1053,7 @@ class COSAgentRequirer(Object):
         )
         self.peer_relation.data[self._charm.unit][
             f"{CosAgentPeersUnitData.KEY}-{event.unit.name}"
-        ] = data.json()
+        ] = _model_json(data)
 
         # We can't easily tell if the data that was changed is limited to only the data
         # that goes into peer relation (in which case, if this is not a leader unit, we wouldn't

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,6 @@ exclude = [
 [tool.pytest.ini_options]
 minversion = "6.0"
 log_cli_level = "INFO"
-asyncio_mode = "auto"
 addopts = "--tb=native --verbose --capture=no --log-cli-level=INFO"
 
 [tool.codespell]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,9 +66,10 @@ convention = "google"
 [tool.pyright]
 extraPaths = ["src", "lib"]
 pythonVersion = "3.8"
-pythonPlatfrom = "All"
+pythonPlatform = "All"
 exclude = [
-  "src/vector.py"
+  "src/vector.py",
+  "tests/manual",
 ]
 
 [tool.pytest.ini_options]

--- a/src/charm.py
+++ b/src/charm.py
@@ -614,40 +614,65 @@ class COSProxyCharm(CharmBase):
         stored state.
         """
         if event and isinstance(event, NrpeTargetsChangedEvent):
-            for target in event.removed_targets:
-                self.metrics_aggregator.remove_prometheus_jobs(target)  # type: ignore
-
-            for alert in event.removed_alerts:
-                self.metrics_aggregator.remove_alert_rules(
-                    self.metrics_aggregator.group_name(alert["labels"]["juju_unit"]),  # type: ignore
-                    alert["labels"]["juju_unit"],  # type: ignore
-                )
-
             nrpes = cast(List[Dict[str, Any]], event.current_targets)
             current_alerts = event.current_alerts
+            removed_targets = event.removed_targets
+            removed_alerts = event.removed_alerts
         else:
             # If the event arg is None, then the stored state value is already up-to-date.
             nrpes = self.nrpe_exporter.endpoints()
             current_alerts = self.nrpe_exporter.alerts()
+            removed_targets = []
+            removed_alerts = []
 
         self._modify_enrichment_file(endpoints=nrpes)
 
-        # Add scrape jobs for prometheus and cos-agent relations
-        for nrpe in nrpes:
-            self.metrics_aggregator.set_target_job_data(
-                nrpe["target"], nrpe["app_name"], **nrpe["additional_fields"]
-            )
+        if not self.unit.is_leader():
+            return
+
+        removed_target_jobs = [
+            {"job_name": target, "unit_name": ""} for target in removed_targets
+        ]
+        removed_alert_rules = [
+            {
+                "group_name": self.metrics_aggregator.group_name(
+                    alert["labels"]["juju_unit"]  # type: ignore
+                ),
+                "unit_name": alert["labels"]["juju_unit"],  # type: ignore
+            }
+            for alert in removed_alerts
+        ]
+
+        # Add scrape jobs for prometheus and cos-agent relations.
+        target_jobs = [
+            {
+                "targets": nrpe["target"],
+                "app_name": nrpe["app_name"],
+                "kwargs": nrpe["additional_fields"],
+            }
+            for nrpe in nrpes
+        ]
+
         # NOTE: We never stop vector once started, so we assume that within an NRPE event, the
         #       vector target can be scraped in the future
         vector_target = {self.unit.name: {"hostname": self.host, "port": VECTOR_PORT}}
-        self.metrics_aggregator.set_target_job_data(vector_target, self.app.name)
+        target_jobs.append({"targets": vector_target, "app_name": self.app.name})
 
-        for alert in current_alerts:
-            self.metrics_aggregator.set_alert_rule_data(
-                re.sub(r"/", "_", alert["labels"]["juju_unit"]),  # type: ignore
-                alert,  # type: ignore
-                label_rules=False,
-            )
+        alert_rules = [
+            {
+                "name": re.sub(r"/", "_", alert["labels"]["juju_unit"]),  # type: ignore
+                "unit_rules": alert,
+                "label_rules": False,
+            }
+            for alert in current_alerts
+        ]
+
+        self.metrics_aggregator.set_target_job_and_alert_rule_data_batch(
+            target_jobs,
+            alert_rules,
+            removed_target_jobs=removed_target_jobs,
+            removed_alert_rules=removed_alert_rules,
+        )
 
     def _set_status(self, _event):
         # Put charm in blocked status if all incoming relations are missing

--- a/src/metrics_endpoint_aggregator.py
+++ b/src/metrics_endpoint_aggregator.py
@@ -308,6 +308,141 @@ class MetricsEndpointAggregator(Object):
             if not _type_convert_stored(self._stored.jobs) == jobs:  # pyright: ignore
                 self._stored.jobs = jobs
 
+    def set_target_job_and_alert_rule_data_batch(
+        self,
+        target_jobs: List[Dict[str, Any]],
+        alert_rules: List[Dict[str, Any]],
+        removed_target_jobs: Optional[List[Dict[str, Any]]] = None,
+        removed_alert_rules: Optional[List[Dict[str, Any]]] = None,
+    ) -> None:
+        """Update scrape jobs and alert rules for a batch of generated NRPE data.
+
+        This method uses the same scrape job and alert rule merge contexts as
+        the per-item update methods, but applies all changes in memory before
+        writing downstream relation data.
+        """
+        if not self._charm.unit.is_leader():
+            return
+
+        scrape_job_contexts = [
+            ScrapeJobContext(
+                removed_job_name=job["job_name"],
+                removed_unit_name=job.get("unit_name", ""),
+            )
+            for job in removed_target_jobs or []
+        ]
+
+        alert_rule_contexts = [
+            AlertRuleContext(
+                removed_group_name=alert_rule["group_name"],
+                removed_unit_name=alert_rule["unit_name"],
+            )
+            for alert_rule in removed_alert_rules or []
+        ]
+
+        scrape_job_contexts.extend(
+            [
+                ScrapeJobContext(
+                    updated_job=self._scrape_config.from_targets(
+                        job["targets"],
+                        job["app_name"],
+                        **job.get("kwargs", {}),
+                    )
+                )
+                for job in target_jobs
+            ]
+        )
+
+        for alert_rule in alert_rules:
+            if alert_rule.get("label_rules", True):
+                rules = self._label_alert_rules(alert_rule["unit_rules"], alert_rule["name"])
+            else:
+                rules = [alert_rule["unit_rules"]]
+            alert_rule_contexts.append(
+                AlertRuleContext(
+                    updated_group={
+                        "name": self.group_name(alert_rule["name"]),
+                        "rules": rules,
+                    }
+                )
+            )
+
+        if self._should_update_cos_agent():
+            self._update_cos_agent_batch(scrape_job_contexts, alert_rule_contexts)
+
+        for relation in self.model.relations[self._prometheus_relation]:
+            updates = {}
+
+            if scrape_job_contexts:
+                jobs = json.loads(relation.data[self._charm.app].get("scrape_jobs", "[]"))
+                for scrape_job_context in scrape_job_contexts:
+                    jobs = scrape_job_context.get_updated_jobs(jobs)
+                updates["scrape_jobs"] = json.dumps(jobs)
+
+                if not _type_convert_stored(self._stored.jobs) == jobs:  # pyright: ignore
+                    self._stored.jobs = jobs
+
+            if alert_rule_contexts:
+                alert_rules_data = json.loads(
+                    relation.data[self._charm.app].get("alert_rules", "{}")
+                )
+                groups = alert_rules_data.get("groups", [])
+                for alert_rule_context in alert_rule_contexts:
+                    groups = alert_rule_context.get_updated_groups({"groups": groups})
+                updates["alert_rules"] = json.dumps(
+                    {"groups": groups if self._forward_alert_rules else []}
+                )
+
+                if not _type_convert_stored(self._stored.alert_rules) == groups:  # pyright: ignore
+                    self._stored.alert_rules = groups
+
+            if updates:
+                relation.data[self._charm.app].update(updates)
+
+    def _update_cos_agent_batch(
+        self,
+        scrape_job_contexts: List["ScrapeJobContext"],
+        alert_rule_contexts: List["AlertRuleContext"],
+    ):
+        """Coordinate cos-agent with batched alert rule and scrape config changes."""
+        if not self._should_update_cos_agent():
+            return
+
+        for relation in self.model.relations[self._charm.cos_agent._relation_name]:
+            if not (config_str := relation.data[self._charm.unit].get("config")):
+                continue
+
+            config = json.loads(config_str)
+
+            if scrape_job_contexts:
+                jobs = config.get("metrics_scrape_jobs", [])
+                for scrape_job_context in scrape_job_contexts:
+                    jobs = scrape_job_context.get_updated_jobs(jobs)
+                config["metrics_scrape_jobs"] = jobs
+                if not _type_convert_stored(self._stored.jobs) == jobs:  # pyright: ignore
+                    self._stored.jobs = jobs
+
+            metrics_alert_rules = config.get("metrics_alert_rules", {})
+            if alert_rule_contexts:
+                groups = metrics_alert_rules.get("groups", [])
+                for alert_rule_context in alert_rule_contexts:
+                    groups = alert_rule_context.get_updated_groups({"groups": groups})
+                config["metrics_alert_rules"] = {
+                    "groups": groups if self._forward_alert_rules else []
+                }
+                if not _type_convert_stored(self._stored.alert_rules) == groups:  # pyright: ignore
+                    self._stored.alert_rules = groups
+
+            relation.data[self._charm.unit]["config"] = json.dumps(config)
+
+    def _should_update_cos_agent(self) -> bool:
+        """Return whether cos-agent should receive data directly from the aggregator."""
+        if not hasattr(self._charm, "cos_agent"):
+            return False
+        cos_agent_relations = self.model.relations[self._charm.cos_agent._relation_name]
+        prom_relations = self.model.relations[self._prometheus_relation]
+        return bool(cos_agent_relations and not prom_relations)
+
     def _on_prometheus_targets_departed(self, event):
         """Remove scrape jobs when a target departs.
 
@@ -330,38 +465,33 @@ class MetricsEndpointAggregator(Object):
 
         WARNING: This method creates a dependency between COSAgentProvider and MetricsEndpointAggregator.
         """
-        if not hasattr(self._charm, "cos_agent"):
+        if not self._should_update_cos_agent():
             return
-        cos_agent_relations = self.model.relations[self._charm.cos_agent._relation_name]
-        prom_relations = self.model.relations[self._prometheus_relation]
-        if cos_agent_relations and not prom_relations:
-            for relation in cos_agent_relations:
-                if not (config_str := relation.data[self._charm.unit].get("config")):
-                    continue
+        for relation in self.model.relations[self._charm.cos_agent._relation_name]:
+            if not (config_str := relation.data[self._charm.unit].get("config")):
+                continue
 
-                config = json.loads(config_str)
+            config = json.loads(config_str)
 
-                # Scrape configs
-                if scrape_job_context is not None:
-                    jobs = scrape_job_context.get_updated_jobs(config.get("metrics_scrape_jobs", []))
-                    config["metrics_scrape_jobs"] = jobs
-                    if not _type_convert_stored(self._stored.jobs) == jobs:  # pyright: ignore
-                        self._stored.jobs = jobs
+            # Scrape configs
+            if scrape_job_context is not None:
+                jobs = scrape_job_context.get_updated_jobs(config.get("metrics_scrape_jobs", []))
+                config["metrics_scrape_jobs"] = jobs
+                if not _type_convert_stored(self._stored.jobs) == jobs:  # pyright: ignore
+                    self._stored.jobs = jobs
 
-                # Alert rules
-                metrics_alert_rules = config.get("metrics_alert_rules", {})
-                if alert_rule_context is not None:
-                    groups = alert_rule_context.get_updated_groups(metrics_alert_rules)
-                else:
-                    groups = metrics_alert_rules.get("groups", [])
-                config["metrics_alert_rules"] = {
-                    "groups": groups if self._forward_alert_rules else []
-                }
-                if not _type_convert_stored(self._stored.alert_rules) == groups:  # pyright: ignore
-                    self._stored.alert_rules = groups
+            # Alert rules
+            metrics_alert_rules = config.get("metrics_alert_rules", {})
+            if alert_rule_context is not None:
+                groups = alert_rule_context.get_updated_groups(metrics_alert_rules)
+            else:
+                groups = metrics_alert_rules.get("groups", [])
+            config["metrics_alert_rules"] = {"groups": groups if self._forward_alert_rules else []}
+            if not _type_convert_stored(self._stored.alert_rules) == groups:  # pyright: ignore
+                self._stored.alert_rules = groups
 
-                # Update relation data
-                relation.data[self._charm.unit]["config"] = json.dumps(config)
+            # Update relation data
+            relation.data[self._charm.unit]["config"] = json.dumps(config)
 
     def remove_prometheus_jobs(self, job_name: str, unit_name: Optional[str] = ""):
         """Given a job name and unit name, remove scrape jobs associated.
@@ -630,8 +760,7 @@ class AlertRuleContext:
 
     def get_updated_groups(self, alert_rules: Dict[str, Any]) -> List[Dict[str, Any]]:
         """Return the resulting list of alert rule groups when the desired state has changed."""
-        if not (groups := _dedupe_list(alert_rules.get("groups", []))):
-            return groups
+        groups = _dedupe_list(alert_rules.get("groups", []))
 
         # Add alert rule groups
         for group in groups:

--- a/tests/manual/benchmark_monitors_fanout.py
+++ b/tests/manual/benchmark_monitors_fanout.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Benchmark monitors-relation-changed downstream write amplification.
+
+This script builds a synthetic monitors relation using the real charm code path,
+then measures downstream write amplification for either one steady-state hook or
+an incremental setup where units arrive one at a time. It reports the observed
+batched relation-set call counts/payload bytes and compares them with the write
+counts the previous sequential implementation would have needed.
+"""
+
+import argparse
+import json
+import tempfile
+import time
+from pathlib import Path
+from typing import Dict
+from unittest.mock import patch
+
+from ops.model import RelationDataContent
+from ops.testing import Harness
+
+from charm import COSProxyCharm
+
+NAGIOS_HOST_CONTEXT = "ubuntu"
+
+
+def monitor_payload(check_count: int) -> str:
+    checks = {f"check_{idx:03d}": f"check_{idx:03d}" for idx in range(check_count)}
+    return json.dumps({"monitors": {"remote": {"nrpe": checks}}, "version": "0.3"})
+
+
+def unit_data(unit_id: int, check_count: int) -> Dict[str, str]:
+    addr = f"10.41.{unit_id // 255}.{unit_id % 255}"
+    return {
+        "egress-subnets": f"{addr}/32",
+        "ingress-address": addr,
+        "machine_id": str(unit_id),
+        "model_id": "fe2c9bbb-58ab-40e4-8f70-f27480093fca",
+        "monitors": monitor_payload(check_count),
+        "private-address": addr,
+        "target-address": addr,
+        "target-id": f"{NAGIOS_HOST_CONTEXT}-ubuntu-{unit_id}",
+        "nagios_host_context": NAGIOS_HOST_CONTEXT,
+    }
+
+
+def fmt_bytes(value: int) -> str:
+    for unit in ("B", "KiB", "MiB", "GiB"):
+        if value < 1024 or unit == "GiB":
+            return f"{value:.1f} {unit}" if unit != "B" else f"{value} {unit}"
+        value = value / 1024
+    raise AssertionError("unreachable")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--units", type=int, default=200)
+    parser.add_argument("--checks", type=int, default=3)
+    parser.add_argument(
+        "--mode",
+        choices=("steady-state", "incremental"),
+        default="steady-state",
+        help=(
+            "steady-state measures one changed event after all units are present; "
+            "incremental measures adding units one at a time with hooks enabled."
+        ),
+    )
+    parser.add_argument(
+        "--commit-ms",
+        type=float,
+        default=0.0,
+        help="Optional modeled fixed latency per relation-set call.",
+    )
+    parser.add_argument(
+        "--kib-ms",
+        type=float,
+        default=0.0,
+        help="Optional modeled latency per KiB sent through relation-set.",
+    )
+    args = parser.parse_args()
+
+    mock_enrichment_file = Path(tempfile.mkstemp()[1])
+    relation_set_calls = 0
+    relation_set_key_updates = {"scrape_jobs": 0, "alert_rules": 0}
+    relation_set_payload_bytes = {"scrape_jobs": 0, "alert_rules": 0}
+    original_commit = RelationDataContent._commit
+
+    def count_commit(databag, data):
+        nonlocal relation_set_calls
+        if any(key in data for key in relation_set_key_updates):
+            relation_set_calls += 1
+        for key in relation_set_key_updates:
+            if key in data:
+                payload_size = len(data[key].encode())
+                relation_set_key_updates[key] += 1
+                relation_set_payload_bytes[key] += payload_size
+        return original_commit(databag, data)
+
+    patches = [
+        patch("charm.remove_package"),
+        patch.object(COSProxyCharm, "_setup_nrpe_exporter"),
+        patch.object(COSProxyCharm, "_start_vector"),
+        patch.object(COSProxyCharm, "path", property(lambda *_: mock_enrichment_file)),
+        patch("socket.gethostbyaddr", return_value=("localhost", [], ["10.41.0.1"])),
+        patch.object(RelationDataContent, "_commit", new=count_commit),
+    ]
+
+    for p in patches:
+        p.start()
+
+    try:
+        harness = Harness(COSProxyCharm)
+        harness.add_network("10.41.0.1")
+        harness.set_model_info(name="mymodel", uuid="fe2c9bbb-58ab-40e4-8f70-f27480093fca")
+        harness.set_leader(True)
+        harness.begin_with_initial_hooks()
+
+        rel_id_nrpe = harness.add_relation("monitors", "nrpe")
+        rel_id_prom = harness.add_relation("downstream-prometheus-scrape", "prom")
+        harness.add_relation_unit(rel_id_prom, "prom/0")
+
+        relation_set_calls = 0
+        relation_set_key_updates.update({"scrape_jobs": 0, "alert_rules": 0})
+        relation_set_payload_bytes.update({"scrape_jobs": 0, "alert_rules": 0})
+        started = time.monotonic()
+
+        if args.mode == "steady-state":
+            harness.disable_hooks()
+            for unit_id in range(args.units):
+                harness.add_relation_unit(rel_id_nrpe, f"nrpe/{unit_id}")
+                harness.update_relation_data(
+                    rel_id_nrpe, f"nrpe/{unit_id}", unit_data(unit_id, args.checks)
+                )
+            harness.enable_hooks()
+
+            trigger_data = unit_data(args.units - 1, args.checks)
+            trigger_data["benchmark-trigger"] = str(time.monotonic())
+            harness.update_relation_data(rel_id_nrpe, f"nrpe/{args.units - 1}", trigger_data)
+            sequential_total_calls = args.units * args.checks * 2 + 1
+            sequential_key_updates = {
+                "scrape_jobs": args.units * args.checks + 1,
+                "alert_rules": args.units * args.checks,
+            }
+        else:
+            for unit_id in range(args.units):
+                harness.add_relation_unit(rel_id_nrpe, f"nrpe/{unit_id}")
+                harness.update_relation_data(
+                    rel_id_nrpe, f"nrpe/{unit_id}", unit_data(unit_id, args.checks)
+                )
+            sequential_key_updates = {
+                "scrape_jobs": args.checks * args.units * (args.units + 1) // 2
+                + args.units,
+                "alert_rules": args.checks * args.units * (args.units + 1) // 2,
+            }
+            sequential_total_calls = sum(sequential_key_updates.values())
+
+        elapsed = time.monotonic() - started
+
+        final_data = harness.get_relation_data(rel_id_prom, "cos-proxy")
+        batched_bytes = {
+            "scrape_jobs": len(final_data["scrape_jobs"].encode()),
+            "alert_rules": len(final_data["alert_rules"].encode()),
+        }
+        current_total_key_updates = sum(relation_set_key_updates.values())
+        current_total_bytes = sum(relation_set_payload_bytes.values())
+        batched_total_bytes = sum(batched_bytes.values())
+        if args.mode == "incremental":
+            batched_total_bytes *= args.units
+
+        batched_modeled_ms = (
+            relation_set_calls * args.commit_ms + current_total_bytes / 1024 * args.kib_ms
+        )
+        sequential_modeled_ms = (
+            sequential_total_calls * args.commit_ms + current_total_bytes / 1024 * args.kib_ms
+        )
+
+        print(f"units: {args.units}")
+        print(f"checks_per_unit: {args.checks}")
+        print(f"mode: {args.mode}")
+        print(f"generated_nrpe_targets: {args.units * args.checks}")
+        print(f"local_wall_time_seconds: {elapsed:.3f}")
+        print()
+        print("batched implementation:")
+        print(f"  relation_set_calls: {relation_set_calls}")
+        print(f"  scrape_jobs_key_updates: {relation_set_key_updates['scrape_jobs']}")
+        print(f"  alert_rules_key_updates: {relation_set_key_updates['alert_rules']}")
+        print(f"  total_key_updates: {current_total_key_updates}")
+        print(f"  relation_set_payload_bytes: {fmt_bytes(current_total_bytes)}")
+        print()
+        print("sequential estimate:")
+        print(f"  relation_set_calls: {sequential_total_calls}")
+        print(f"  scrape_jobs_key_updates: {sequential_key_updates['scrape_jobs']}")
+        print(f"  alert_rules_key_updates: {sequential_key_updates['alert_rules']}")
+        print(f"  total_key_updates: {sum(sequential_key_updates.values())}")
+        if args.mode == "incremental":
+            print(f"  relation_set_payload_bytes: {fmt_bytes(batched_total_bytes)}")
+            print("  byte_estimate: upper bound using the final payload size for every hook")
+        else:
+            print(f"  relation_set_payload_bytes: {fmt_bytes(batched_total_bytes)}")
+        print()
+        print("reduction:")
+        print(f"  relation_set_calls: {sequential_total_calls / relation_set_calls:.1f}x")
+        print(f"  key_updates: {sum(sequential_key_updates.values()) / current_total_key_updates:.1f}x")
+        if args.commit_ms or args.kib_ms:
+            print()
+            print("modeled latency:")
+            print(f"  batched_ms: {batched_modeled_ms:.1f}")
+            print(f"  sequential_ms: {sequential_modeled_ms:.1f}")
+            print(f"  saved_ms: {sequential_modeled_ms - batched_modeled_ms:.1f}")
+    finally:
+        for p in reversed(patches):
+            p.stop()
+        mock_enrichment_file.unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/manual/benchmark_monitors_fanout.py
+++ b/tests/manual/benchmark_monitors_fanout.py
@@ -79,7 +79,8 @@ def main():
     )
     args = parser.parse_args()
 
-    mock_enrichment_file = Path(tempfile.mkstemp()[1])
+    with tempfile.NamedTemporaryFile(delete=False) as tf:
+        mock_enrichment_file = Path(tf.name)
     relation_set_calls = 0
     relation_set_key_updates = {"scrape_jobs": 0, "alert_rules": 0}
     relation_set_payload_bytes = {"scrape_jobs": 0, "alert_rules": 0}

--- a/tests/manual/charms/monitors-provider/charmcraft.yaml
+++ b/tests/manual/charms/monitors-provider/charmcraft.yaml
@@ -1,0 +1,25 @@
+name: monitors-provider
+type: charm
+summary: Emits synthetic NRPE monitor relation data.
+description: Emits synthetic NRPE monitor relation data for COS Proxy benchmarks.
+
+platforms:
+  ubuntu@22.04:amd64:
+  ubuntu@24.04:amd64:
+
+provides:
+  monitors:
+    interface: monitors
+
+config:
+  options:
+    checks:
+      type: int
+      default: 3
+      description: Number of NRPE checks to emit from each unit.
+
+parts:
+  charm:
+    source: .
+    plugin: uv
+    build-snaps: [astral-uv]

--- a/tests/manual/charms/monitors-provider/pyproject.toml
+++ b/tests/manual/charms/monitors-provider/pyproject.toml
@@ -1,0 +1,5 @@
+[project]
+name = "monitors-provider"
+version = "0.0"
+requires-python = ">=3.10"
+dependencies = ["ops<3"]

--- a/tests/manual/charms/monitors-provider/src/charm.py
+++ b/tests/manual/charms/monitors-provider/src/charm.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+import json
+
+from ops import ActiveStatus, CharmBase, main
+
+
+class MonitorsProviderCharm(CharmBase):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.framework.observe(self.on.config_changed, self._publish)
+        self.framework.observe(self.on.monitors_relation_joined, self._publish)
+
+    def _publish(self, _):
+        checks = int(self.config["checks"])
+        unit_id = int(self.unit.name.split("/")[1])
+        address = self.model.get_binding("monitors").network.bind_address
+        monitors = {
+            "version": "0.3",
+            "monitors": {
+                "remote": {
+                    "nrpe": {
+                        f"check_{idx:03d}": f"check_{idx:03d}" for idx in range(checks)
+                    }
+                }
+            },
+        }
+
+        for relation in self.model.relations["monitors"]:
+            relation.data[self.unit].update(
+                {
+                    "egress-subnets": f"{address}/32",
+                    "ingress-address": str(address),
+                    "machine_id": str(unit_id),
+                    "model_id": self.model.uuid,
+                    "monitors": json.dumps(monitors),
+                    "private-address": str(address),
+                    "target-address": str(address),
+                    "target-id": f"benchmark-monitors-provider-{unit_id}",
+                    "nagios_host_context": "benchmark",
+                }
+            )
+
+        self.unit.status = ActiveStatus(f"checks={checks}")
+
+
+if __name__ == "__main__":
+    main(MonitorsProviderCharm)

--- a/tests/manual/charms/monitors-provider/uv.lock
+++ b/tests/manual/charms/monitors-provider/uv.lock
@@ -1,0 +1,144 @@
+version = 1
+revision = 3
+requires-python = ">=3.10"
+
+[[package]]
+name = "importlib-metadata"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
+]
+
+[[package]]
+name = "monitors-provider"
+version = "0.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "ops" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "ops", specifier = "<3" }]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.42.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/1c/125e1c936c0873796771b7f04f6c93b9f1bf5d424cea90fda94a99f61da8/opentelemetry_api-1.42.1.tar.gz", hash = "sha256:56c63bea9f77b62856be8c47600474acad853b2924b99b1687c4cb6297166716", size = 72296, upload-time = "2026-05-21T16:32:49.335Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/ca/9520cc1f3dfbbd03ac5903bbf55833e257bc64b1cf30fa8b0d6df374d821/opentelemetry_api-1.42.1-py3-none-any.whl", hash = "sha256:51a69edacadbc03a8950ace1c4c21099cacc538820ac2c9e36277e78cebba714", size = 61311, upload-time = "2026-05-21T16:32:28.822Z" },
+]
+
+[[package]]
+name = "ops"
+version = "2.23.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "opentelemetry-api" },
+    { name = "pyyaml" },
+    { name = "websocket-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/93/98/84789a5e15ad76e043301bbd70b4d39cffaa717ae6eecb662fd0dd0cc7af/ops-2.23.2.tar.gz", hash = "sha256:a69b0c5bc65ebd91720fc96459e81b969df851f3a6c9c855ee73de7004205987", size = 528074, upload-time = "2026-02-11T03:58:15.565Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/00/65da7c96d0f9e13c4de3bdd2e3717259fe723ff4bd4e5dc714164f851032/ops-2.23.2-py3-none-any.whl", hash = "sha256:9cab0c6bc46eeff2e96777128200c3ef872b55641b12f07dc4fd6fe3103954be", size = 188415, upload-time = "2026-02-11T03:58:13.693Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/a0/39350dd17dd6d6c6507025c0e53aef67a9293a6d37d3511f23ea510d5800/pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b", size = 184227, upload-time = "2025-09-25T21:31:46.04Z" },
+    { url = "https://files.pythonhosted.org/packages/05/14/52d505b5c59ce73244f59c7a50ecf47093ce4765f116cdb98286a71eeca2/pyyaml-6.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956", size = 174019, upload-time = "2025-09-25T21:31:47.706Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f7/0e6a5ae5599c838c696adb4e6330a59f463265bfa1e116cfd1fbb0abaaae/pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8", size = 740646, upload-time = "2025-09-25T21:31:49.21Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/3a/61b9db1d28f00f8fd0ae760459a5c4bf1b941baf714e207b6eb0657d2578/pyyaml-6.0.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:66291b10affd76d76f54fad28e22e51719ef9ba22b29e1d7d03d6777a9174198", size = 840793, upload-time = "2025-09-25T21:31:50.735Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1e/7acc4f0e74c4b3d9531e24739e0ab832a5edf40e64fbae1a9c01941cabd7/pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c7708761fccb9397fe64bbc0395abcae8c4bf7b0eac081e12b809bf47700d0b", size = 770293, upload-time = "2025-09-25T21:31:51.828Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/ef/abd085f06853af0cd59fa5f913d61a8eab65d7639ff2a658d18a25d6a89d/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:418cf3f2111bc80e0933b2cd8cd04f286338bb88bdc7bc8e6dd775ebde60b5e0", size = 732872, upload-time = "2025-09-25T21:31:53.282Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/15/2bc9c8faf6450a8b3c9fc5448ed869c599c0a74ba2669772b1f3a0040180/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5e0b74767e5f8c593e8c9b5912019159ed0533c70051e9cce3e8b6aa699fcd69", size = 758828, upload-time = "2025-09-25T21:31:54.807Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/00/531e92e88c00f4333ce359e50c19b8d1de9fe8d581b1534e35ccfbc5f393/pyyaml-6.0.3-cp310-cp310-win32.whl", hash = "sha256:28c8d926f98f432f88adc23edf2e6d4921ac26fb084b028c733d01868d19007e", size = 142415, upload-time = "2025-09-25T21:31:55.885Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fa/926c003379b19fca39dd4634818b00dec6c62d87faf628d1394e137354d4/pyyaml-6.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:bdb2c67c6c1390b63c6ff89f210c8fd09d9a1217a465701eac7316313c915e4c", size = 158561, upload-time = "2025-09-25T21:31:57.406Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "websocket-client"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
+]

--- a/tests/manual/charms/scrape-consumer/charmcraft.yaml
+++ b/tests/manual/charms/scrape-consumer/charmcraft.yaml
@@ -1,0 +1,18 @@
+name: scrape-consumer
+type: charm
+summary: Consumes prometheus_scrape relation data.
+description: Consumes prometheus_scrape relation data for COS Proxy benchmarks.
+
+platforms:
+  ubuntu@22.04:amd64:
+  ubuntu@24.04:amd64:
+
+requires:
+  downstream-prometheus-scrape:
+    interface: prometheus_scrape
+
+parts:
+  charm:
+    source: .
+    plugin: uv
+    build-snaps: [astral-uv]

--- a/tests/manual/charms/scrape-consumer/pyproject.toml
+++ b/tests/manual/charms/scrape-consumer/pyproject.toml
@@ -1,0 +1,5 @@
+[project]
+name = "scrape-consumer"
+version = "0.0"
+requires-python = ">=3.10"
+dependencies = ["ops<3"]

--- a/tests/manual/charms/scrape-consumer/src/charm.py
+++ b/tests/manual/charms/scrape-consumer/src/charm.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+import json
+
+from ops import ActiveStatus, CharmBase, WaitingStatus, main
+
+
+class ScrapeConsumerCharm(CharmBase):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.framework.observe(self.on.downstream_prometheus_scrape_relation_joined, self._update)
+        self.framework.observe(self.on.downstream_prometheus_scrape_relation_changed, self._update)
+        self.unit.status = WaitingStatus("waiting for scrape data")
+
+    def _update(self, _):
+        for relation in self.model.relations["downstream-prometheus-scrape"]:
+            if not relation.app:
+                continue
+            data = relation.data[relation.app]
+            scrape_jobs = json.loads(data.get("scrape_jobs", "[]"))
+            alert_rules = json.loads(data.get("alert_rules", "{}"))
+            groups = alert_rules.get("groups", [])
+            rule_count = sum(len(group.get("rules", [])) for group in groups)
+            self.unit.status = ActiveStatus(
+                f"scrape_jobs={len(scrape_jobs)} alert_rules={rule_count}"
+            )
+            return
+
+        self.unit.status = WaitingStatus("waiting for scrape data")
+
+
+if __name__ == "__main__":
+    main(ScrapeConsumerCharm)

--- a/tests/manual/charms/scrape-consumer/uv.lock
+++ b/tests/manual/charms/scrape-consumer/uv.lock
@@ -1,0 +1,144 @@
+version = 1
+revision = 3
+requires-python = ">=3.10"
+
+[[package]]
+name = "importlib-metadata"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.42.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/1c/125e1c936c0873796771b7f04f6c93b9f1bf5d424cea90fda94a99f61da8/opentelemetry_api-1.42.1.tar.gz", hash = "sha256:56c63bea9f77b62856be8c47600474acad853b2924b99b1687c4cb6297166716", size = 72296, upload-time = "2026-05-21T16:32:49.335Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/ca/9520cc1f3dfbbd03ac5903bbf55833e257bc64b1cf30fa8b0d6df374d821/opentelemetry_api-1.42.1-py3-none-any.whl", hash = "sha256:51a69edacadbc03a8950ace1c4c21099cacc538820ac2c9e36277e78cebba714", size = 61311, upload-time = "2026-05-21T16:32:28.822Z" },
+]
+
+[[package]]
+name = "ops"
+version = "2.23.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "opentelemetry-api" },
+    { name = "pyyaml" },
+    { name = "websocket-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/93/98/84789a5e15ad76e043301bbd70b4d39cffaa717ae6eecb662fd0dd0cc7af/ops-2.23.2.tar.gz", hash = "sha256:a69b0c5bc65ebd91720fc96459e81b969df851f3a6c9c855ee73de7004205987", size = 528074, upload-time = "2026-02-11T03:58:15.565Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/00/65da7c96d0f9e13c4de3bdd2e3717259fe723ff4bd4e5dc714164f851032/ops-2.23.2-py3-none-any.whl", hash = "sha256:9cab0c6bc46eeff2e96777128200c3ef872b55641b12f07dc4fd6fe3103954be", size = 188415, upload-time = "2026-02-11T03:58:13.693Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/a0/39350dd17dd6d6c6507025c0e53aef67a9293a6d37d3511f23ea510d5800/pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b", size = 184227, upload-time = "2025-09-25T21:31:46.04Z" },
+    { url = "https://files.pythonhosted.org/packages/05/14/52d505b5c59ce73244f59c7a50ecf47093ce4765f116cdb98286a71eeca2/pyyaml-6.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956", size = 174019, upload-time = "2025-09-25T21:31:47.706Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f7/0e6a5ae5599c838c696adb4e6330a59f463265bfa1e116cfd1fbb0abaaae/pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8", size = 740646, upload-time = "2025-09-25T21:31:49.21Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/3a/61b9db1d28f00f8fd0ae760459a5c4bf1b941baf714e207b6eb0657d2578/pyyaml-6.0.3-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:66291b10affd76d76f54fad28e22e51719ef9ba22b29e1d7d03d6777a9174198", size = 840793, upload-time = "2025-09-25T21:31:50.735Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1e/7acc4f0e74c4b3d9531e24739e0ab832a5edf40e64fbae1a9c01941cabd7/pyyaml-6.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c7708761fccb9397fe64bbc0395abcae8c4bf7b0eac081e12b809bf47700d0b", size = 770293, upload-time = "2025-09-25T21:31:51.828Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/ef/abd085f06853af0cd59fa5f913d61a8eab65d7639ff2a658d18a25d6a89d/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:418cf3f2111bc80e0933b2cd8cd04f286338bb88bdc7bc8e6dd775ebde60b5e0", size = 732872, upload-time = "2025-09-25T21:31:53.282Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/15/2bc9c8faf6450a8b3c9fc5448ed869c599c0a74ba2669772b1f3a0040180/pyyaml-6.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5e0b74767e5f8c593e8c9b5912019159ed0533c70051e9cce3e8b6aa699fcd69", size = 758828, upload-time = "2025-09-25T21:31:54.807Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/00/531e92e88c00f4333ce359e50c19b8d1de9fe8d581b1534e35ccfbc5f393/pyyaml-6.0.3-cp310-cp310-win32.whl", hash = "sha256:28c8d926f98f432f88adc23edf2e6d4921ac26fb084b028c733d01868d19007e", size = 142415, upload-time = "2025-09-25T21:31:55.885Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fa/926c003379b19fca39dd4634818b00dec6c62d87faf628d1394e137354d4/pyyaml-6.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:bdb2c67c6c1390b63c6ff89f210c8fd09d9a1217a465701eac7316313c915e4c", size = 158561, upload-time = "2025-09-25T21:31:57.406Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "scrape-consumer"
+version = "0.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "ops" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "ops", specifier = "<3" }]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "websocket-client"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
+]

--- a/tests/manual/juju_monitors_benchmark.py
+++ b/tests/manual/juju_monitors_benchmark.py
@@ -1,0 +1,369 @@
+"""Manual Juju benchmark for COS Proxy monitors fan-in.
+
+Run with:
+
+    tox -e benchmark
+
+Useful environment variables:
+
+    COS_PROXY_BASELINE_CHARM=cos-proxy
+    COS_PROXY_BASELINE_CHANNEL=2/stable
+    COS_PROXY_BASELINE_REVISION=123
+    COS_PROXY_BASELINE_REF=origin/main
+    COS_PROXY_CANDIDATE_CHARM=/path/to/candidate.charm
+    COS_PROXY_BENCHMARK_CASES=both
+    COS_PROXY_BENCHMARK_UNITS=20
+    COS_PROXY_BENCHMARK_CHECKS=3
+    COS_PROXY_BENCHMARK_TIMEOUT=1800
+    COS_PROXY_BENCHMARK_BASE=ubuntu@22.04
+    COS_PROXY_CHARMCRAFT_PACK_ARGS=--platform ubuntu@22.04:amd64
+
+The benchmark packs two COS Proxy charms:
+
+* baseline: from Charmhub cos-proxy 2/stable by default
+* candidate: from the current working tree, or COS_PROXY_CANDIDATE_CHARM if set
+
+It deploys each into an isolated Juju model with a synthetic monitors provider
+and a synthetic prometheus_scrape consumer, then measures how long the model
+takes to reach the expected downstream scrape/alert counts.
+Results are labelled sequential for the baseline implementation and batched for
+the candidate implementation.
+"""
+
+import hashlib
+import json
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+import jubilant
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ARTIFACTS_DIR = Path(os.environ.get("COS_PROXY_BENCHMARK_ARTIFACTS", REPO_ROOT / ".benchmark"))
+CHARM_CACHE_DIR = ARTIFACTS_DIR / "charms"
+UNITS = int(os.environ.get("COS_PROXY_BENCHMARK_UNITS", "20"))
+CHECKS = int(os.environ.get("COS_PROXY_BENCHMARK_CHECKS", "3"))
+TIMEOUT = int(os.environ.get("COS_PROXY_BENCHMARK_TIMEOUT", "1800"))
+CASES = os.environ.get("COS_PROXY_BENCHMARK_CASES", "both")
+BASE = os.environ.get("COS_PROXY_BENCHMARK_BASE", "ubuntu@22.04")
+BASELINE_CHANNEL = os.environ.get("COS_PROXY_BASELINE_CHANNEL", "2/stable")
+BASELINE_REVISION = os.environ.get("COS_PROXY_BASELINE_REVISION")
+DEFAULT_CHARMCRAFT_PACK_ARGS = f"--platform {BASE}:amd64"
+CHARMCRAFT_PACK_ARGS = tuple(
+    shlex.split(os.environ.get("COS_PROXY_CHARMCRAFT_PACK_ARGS", DEFAULT_CHARMCRAFT_PACK_ARGS))
+)
+COPY_IGNORE = shutil.ignore_patterns(
+    ".benchmark",
+    ".git",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".tox",
+    ".venv",
+    "__pycache__",
+    "*.charm",
+    "*.pyc",
+    "build",
+)
+
+
+def run(*cmd: str, cwd: Path = REPO_ROOT) -> str:
+    print(f"\n$ {' '.join(cmd)}", flush=True)
+    process = subprocess.Popen(
+        cmd,
+        cwd=cwd,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    output_lines = []
+    assert process.stdout is not None
+    for line in process.stdout:
+        print(line, end="", flush=True)
+        output_lines.append(line)
+
+    returncode = process.wait()
+    output = "".join(output_lines)
+    if returncode:
+        raise RuntimeError(
+            f"Command failed in {cwd} with exit code {returncode}: {' '.join(cmd)}\n"
+            f"{output}"
+        )
+    return output
+
+
+def shell_quote(value: str) -> str:
+    return shlex.quote(value)
+
+
+def hash_charm_source(source: Path, *, name: str, version: str | None) -> str:
+    digest = hashlib.sha256()
+    digest.update(name.encode())
+    digest.update(b"\0")
+    digest.update(json.dumps(CHARMCRAFT_PACK_ARGS).encode())
+    digest.update(b"\0")
+    digest.update((version or "").encode())
+    digest.update(b"\0")
+
+    for path in sorted(source.rglob("*")):
+        if not path.is_file():
+            continue
+        relative_path = path.relative_to(source).as_posix()
+        digest.update(relative_path.encode())
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return digest.hexdigest()[:16]
+
+
+def stage_charm_source(source: Path, name: str, version: str | None = None) -> Path:
+    ARTIFACTS_DIR.mkdir(exist_ok=True)
+    stage = ARTIFACTS_DIR / f"{name}-source-{time.time_ns()}"
+    if stage.exists():
+        shutil.rmtree(stage)
+
+    shutil.copytree(source, stage, ignore=COPY_IGNORE)
+    if version is not None:
+        charmcraft_yaml = stage / "charmcraft.yaml"
+        text = charmcraft_yaml.read_text()
+        text = text.replace(
+            "git describe --always > $CRAFT_PART_INSTALL/version",
+            f"printf '%s\\n' {shell_quote(version)} > $CRAFT_PART_INSTALL/version",
+        )
+        charmcraft_yaml.write_text(text)
+    return stage
+
+
+def pack_charm(source: Path, name: str, *, version: str | None = None) -> Path:
+    pack_source = stage_charm_source(source, name, version)
+    cache_key = hash_charm_source(pack_source, name=name, version=version)
+    CHARM_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    destination = CHARM_CACHE_DIR / f"{name}-{cache_key}.charm"
+    if destination.exists():
+        print(f"\nReusing packed charm: {destination}", flush=True)
+        shutil.rmtree(pack_source)
+        return destination
+
+    before = set(pack_source.glob("*.charm"))
+    try:
+        run("charmcraft", "pack", *CHARMCRAFT_PACK_ARGS, cwd=pack_source)
+    except Exception:
+        print(f"\nPreserving failed pack source for debugging: {pack_source}", flush=True)
+        raise
+
+    after = set(pack_source.glob("*.charm"))
+    candidates = sorted(after - before or after, key=lambda path: path.stat().st_mtime)
+    if not candidates:
+        raise RuntimeError(f"charmcraft pack did not produce a charm in {pack_source}")
+
+    packed = candidates[-1]
+    shutil.copy2(packed, destination)
+    shutil.rmtree(pack_source)
+    return destination
+
+
+def pack_cos_proxy_from_ref(ref: str) -> Path:
+    worktree = ARTIFACTS_DIR / f"cos-proxy-baseline-{ref.replace('/', '-')}"
+    if worktree.exists():
+        run("git", "worktree", "remove", "--force", str(worktree))
+    run("git", "worktree", "add", "--detach", str(worktree), ref)
+    try:
+        version = run("git", "describe", "--always", cwd=worktree).strip()
+        return pack_charm(worktree, "cos-proxy-baseline", version=version)
+    finally:
+        run("git", "worktree", "remove", "--force", str(worktree))
+
+
+def pack_candidate() -> Path:
+    if candidate := os.environ.get("COS_PROXY_CANDIDATE_CHARM"):
+        return Path(candidate).resolve()
+    version = run("git", "describe", "--always", "--dirty", cwd=REPO_ROOT).strip()
+    return pack_charm(REPO_ROOT, "cos-proxy-candidate", version=version)
+
+
+def baseline_deploy_spec() -> tuple[str | Path, str, str | None, int | None]:
+    if baseline_charm := os.environ.get("COS_PROXY_BASELINE_CHARM"):
+        revision = int(BASELINE_REVISION) if BASELINE_REVISION else None
+        if baseline_charm.startswith((".", "/")):
+            return Path(baseline_charm).resolve(), f"local:{baseline_charm}", None, None
+        return baseline_charm, f"{baseline_charm}:{BASELINE_CHANNEL}", BASELINE_CHANNEL, revision
+
+    if baseline_ref := os.environ.get("COS_PROXY_BASELINE_REF"):
+        return pack_cos_proxy_from_ref(baseline_ref), f"git:{baseline_ref}", None, None
+
+    revision = int(BASELINE_REVISION) if BASELINE_REVISION else None
+    return "cos-proxy", f"cos-proxy:{BASELINE_CHANNEL}", BASELINE_CHANNEL, revision
+
+
+def relation_counts(juju: jubilant.Juju) -> tuple[int, int]:
+    status = json.loads(juju.cli("status", "--format=json"))
+    units = status["applications"]["scrape-consumer"]["units"]
+    message = units["scrape-consumer/0"]["workload-status"].get("message", "")
+    match = re.search(r"scrape_jobs=(\d+) alert_rules=(\d+)", message)
+    if not match:
+        return 0, 0
+    return int(match.group(1)), int(match.group(2))
+
+
+def wait_for_expected_counts(juju: jubilant.Juju) -> tuple[float, tuple[int, int], bool]:
+    expected_jobs = UNITS * CHECKS + 1
+    expected_alerts = UNITS * CHECKS
+    started = time.monotonic()
+    deadline = started + TIMEOUT
+    last_counts = (0, 0)
+
+    while time.monotonic() < deadline:
+        last_counts = relation_counts(juju)
+        if last_counts[0] >= expected_jobs and last_counts[1] >= expected_alerts:
+            juju.wait(lambda status: jubilant.all_agents_idle(status), timeout=TIMEOUT)
+            return time.monotonic() - started, last_counts, False
+        time.sleep(5)
+
+    return time.monotonic() - started, last_counts, True
+
+
+def run_case(
+    juju: jubilant.Juju,
+    *,
+    label: str,
+    cos_proxy_charm: str | Path,
+    cos_proxy_channel: str | None = None,
+    cos_proxy_revision: int | None = None,
+    provider_charm: Path,
+    consumer_charm: Path,
+) -> dict:
+    juju.wait_timeout = TIMEOUT
+    print(f"\n[{label}] deploying applications", flush=True)
+    juju.deploy(
+        cos_proxy_charm,
+        "cos-proxy",
+        base=BASE,
+        channel=cos_proxy_channel,
+        revision=cos_proxy_revision,
+    )
+    juju.deploy(
+        provider_charm,
+        "monitors-provider",
+        base=BASE,
+        config={"checks": CHECKS},
+        num_units=UNITS,
+    )
+    juju.deploy(consumer_charm, "scrape-consumer", base=BASE)
+    print(f"[{label}] waiting for deployed applications to become idle", flush=True)
+    juju.wait(lambda status: jubilant.all_agents_idle(status), timeout=TIMEOUT)
+
+    started = time.monotonic()
+    print(f"[{label}] integrating downstream-prometheus-scrape", flush=True)
+    juju.integrate("cos-proxy:downstream-prometheus-scrape", "scrape-consumer")
+    print(f"[{label}] integrating monitors", flush=True)
+    juju.integrate("cos-proxy:monitors", "monitors-provider:monitors")
+    print(f"[{label}] waiting for expected downstream counts", flush=True)
+    elapsed, counts, timed_out = wait_for_expected_counts(juju)
+    if timed_out:
+        print(f"[{label}] timed out after {elapsed:.1f}s; last counts={counts}", flush=True)
+
+    return {
+        "label": label,
+        "units": UNITS,
+        "checks_per_unit": CHECKS,
+        "timed_out": timed_out,
+        "timeout_seconds": TIMEOUT,
+        "elapsed_seconds": elapsed,
+        "wall_seconds_including_integrate_calls": time.monotonic() - started,
+        "scrape_jobs": counts[0],
+        "alert_rules": counts[1],
+        "model": juju.model,
+    }
+
+
+def destroy_model(juju_factory, juju: jubilant.Juju) -> None:
+    model = juju.model
+    if not model:
+        return
+    print(f"\nDestroying benchmark model before next case: {model}", flush=True)
+    try:
+        juju.destroy_model(model, destroy_storage=True, force=True, timeout=TIMEOUT)
+    except jubilant.CLIError as exc:
+        print(f"WARNING: failed to destroy benchmark model {model}: {exc}", flush=True)
+    finally:
+        # The baseline model is intentionally destroyed before the candidate case to keep
+        # large fan-in benchmarks within local LXD capacity. pytest-jubilant still has the
+        # model registered for final teardown, so unregister it after our explicit destroy.
+        models = getattr(juju_factory, "_models", None)
+        if isinstance(models, dict):
+            models.pop(model, None)
+        juju.model = None
+
+
+def print_results(results: list[dict]) -> None:
+    print("\nCOS Proxy monitors fan-in benchmark")
+    print(json.dumps(results, indent=2))
+
+
+def selected_cases() -> set[str]:
+    cases = {case.strip() for case in CASES.split(",") if case.strip()}
+    if cases == {"both"}:
+        return {"baseline", "candidate"}
+    valid_cases = {"baseline", "candidate"}
+    if not cases or not cases <= valid_cases:
+        raise ValueError(
+            "COS_PROXY_BENCHMARK_CASES must be one of: both, baseline, candidate, "
+            "or a comma-separated combination of baseline,candidate"
+        )
+    return cases
+
+
+def test_cos_proxy_monitors_fan_in_benchmark(juju_factory):
+    cases = selected_cases()
+    provider_charm = pack_charm(REPO_ROOT / "tests/manual/charms/monitors-provider", "monitors-provider")
+    consumer_charm = pack_charm(REPO_ROOT / "tests/manual/charms/scrape-consumer", "scrape-consumer")
+
+    results = []
+
+    if "baseline" in cases:
+        baseline_charm, baseline_label, baseline_channel, baseline_revision = baseline_deploy_spec()
+        baseline = juju_factory.get_juju(suffix="baseline")
+        try:
+            baseline_result = run_case(
+                baseline,
+                label=f"sequential:{baseline_label}",
+                cos_proxy_charm=baseline_charm,
+                cos_proxy_channel=baseline_channel,
+                cos_proxy_revision=baseline_revision,
+                provider_charm=provider_charm,
+                consumer_charm=consumer_charm,
+            )
+            results.append(baseline_result)
+            print_results(results)
+        finally:
+            destroy_model(juju_factory, baseline)
+
+    if "candidate" in cases:
+        candidate_charm = pack_candidate()
+        candidate = juju_factory.get_juju(suffix="candidate")
+        candidate_result = run_case(
+            candidate,
+            label="batched:working-tree",
+            cos_proxy_charm=candidate_charm,
+            provider_charm=provider_charm,
+            consumer_charm=consumer_charm,
+        )
+        results.append(candidate_result)
+        print_results(results)
+
+    results_by_case = {
+        result["label"].split(":", 1)[0]: result
+        for result in results
+    }
+    if batched_result := results_by_case.get("batched"):
+        assert not batched_result["timed_out"]
+    if (
+        (sequential_result := results_by_case.get("sequential"))
+        and (batched_result := results_by_case.get("batched"))
+        and not sequential_result["timed_out"]
+    ):
+        assert sequential_result["scrape_jobs"] == batched_result["scrape_jobs"]
+        assert sequential_result["alert_rules"] == batched_result["alert_rules"]

--- a/tests/manual/juju_monitors_benchmark.py
+++ b/tests/manual/juju_monitors_benchmark.py
@@ -6,11 +6,11 @@ Run with:
 
 Useful environment variables:
 
-    COS_PROXY_BASELINE_CHARM=cos-proxy
-    COS_PROXY_BASELINE_CHANNEL=2/stable
-    COS_PROXY_BASELINE_REVISION=123
-    COS_PROXY_BASELINE_REF=origin/main
-    COS_PROXY_CANDIDATE_CHARM=/path/to/candidate.charm
+    COS_PROXY_SEQUENTIAL_CHARM=cos-proxy
+    COS_PROXY_SEQUENTIAL_CHANNEL=2/stable
+    COS_PROXY_SEQUENTIAL_REVISION=123
+    COS_PROXY_SEQUENTIAL_REF=origin/main
+    COS_PROXY_BATCHED_CHARM=/path/to/batched.charm
     COS_PROXY_BENCHMARK_CASES=both
     COS_PROXY_BENCHMARK_UNITS=20
     COS_PROXY_BENCHMARK_CHECKS=3
@@ -20,14 +20,12 @@ Useful environment variables:
 
 The benchmark packs two COS Proxy charms:
 
-* baseline: from Charmhub cos-proxy 2/stable by default
-* candidate: from the current working tree, or COS_PROXY_CANDIDATE_CHARM if set
+* sequential: from Charmhub cos-proxy 2/stable by default
+* batched: from the current working tree, or COS_PROXY_BATCHED_CHARM if set
 
 It deploys each into an isolated Juju model with a synthetic monitors provider
 and a synthetic prometheus_scrape consumer, then measures how long the model
 takes to reach the expected downstream scrape/alert counts.
-Results are labelled sequential for the baseline implementation and batched for
-the candidate implementation.
 """
 
 import hashlib
@@ -50,8 +48,8 @@ CHECKS = int(os.environ.get("COS_PROXY_BENCHMARK_CHECKS", "3"))
 TIMEOUT = int(os.environ.get("COS_PROXY_BENCHMARK_TIMEOUT", "1800"))
 CASES = os.environ.get("COS_PROXY_BENCHMARK_CASES", "both")
 BASE = os.environ.get("COS_PROXY_BENCHMARK_BASE", "ubuntu@22.04")
-BASELINE_CHANNEL = os.environ.get("COS_PROXY_BASELINE_CHANNEL", "2/stable")
-BASELINE_REVISION = os.environ.get("COS_PROXY_BASELINE_REVISION")
+SEQUENTIAL_CHANNEL = os.environ.get("COS_PROXY_SEQUENTIAL_CHANNEL", "2/stable")
+SEQUENTIAL_REVISION = os.environ.get("COS_PROXY_SEQUENTIAL_REVISION")
 DEFAULT_CHARMCRAFT_PACK_ARGS = f"--platform {BASE}:amd64"
 CHARMCRAFT_PACK_ARGS = tuple(
     shlex.split(os.environ.get("COS_PROXY_CHARMCRAFT_PACK_ARGS", DEFAULT_CHARMCRAFT_PACK_ARGS))
@@ -166,36 +164,36 @@ def pack_charm(source: Path, name: str, *, version: str | None = None) -> Path:
 
 
 def pack_cos_proxy_from_ref(ref: str) -> Path:
-    worktree = ARTIFACTS_DIR / f"cos-proxy-baseline-{ref.replace('/', '-')}"
+    worktree = ARTIFACTS_DIR / f"cos-proxy-sequential-{ref.replace('/', '-')}"
     if worktree.exists():
         run("git", "worktree", "remove", "--force", str(worktree))
     run("git", "worktree", "add", "--detach", str(worktree), ref)
     try:
         version = run("git", "describe", "--always", cwd=worktree).strip()
-        return pack_charm(worktree, "cos-proxy-baseline", version=version)
+        return pack_charm(worktree, "cos-proxy-sequential", version=version)
     finally:
         run("git", "worktree", "remove", "--force", str(worktree))
 
 
-def pack_candidate() -> Path:
-    if candidate := os.environ.get("COS_PROXY_CANDIDATE_CHARM"):
-        return Path(candidate).resolve()
+def pack_batched() -> Path:
+    if batched_charm := os.environ.get("COS_PROXY_BATCHED_CHARM"):
+        return Path(batched_charm).resolve()
     version = run("git", "describe", "--always", "--dirty", cwd=REPO_ROOT).strip()
-    return pack_charm(REPO_ROOT, "cos-proxy-candidate", version=version)
+    return pack_charm(REPO_ROOT, "cos-proxy-batched", version=version)
 
 
-def baseline_deploy_spec() -> tuple[str | Path, str, str | None, int | None]:
-    if baseline_charm := os.environ.get("COS_PROXY_BASELINE_CHARM"):
-        revision = int(BASELINE_REVISION) if BASELINE_REVISION else None
-        if baseline_charm.startswith((".", "/")):
-            return Path(baseline_charm).resolve(), f"local:{baseline_charm}", None, None
-        return baseline_charm, f"{baseline_charm}:{BASELINE_CHANNEL}", BASELINE_CHANNEL, revision
+def sequential_deploy_spec() -> tuple[str | Path, str, str | None, int | None]:
+    if sequential_charm := os.environ.get("COS_PROXY_SEQUENTIAL_CHARM"):
+        revision = int(SEQUENTIAL_REVISION) if SEQUENTIAL_REVISION else None
+        if sequential_charm.startswith((".", "/")):
+            return Path(sequential_charm).resolve(), f"local:{sequential_charm}", None, None
+        return sequential_charm, f"{sequential_charm}:{SEQUENTIAL_CHANNEL}", SEQUENTIAL_CHANNEL, revision
 
-    if baseline_ref := os.environ.get("COS_PROXY_BASELINE_REF"):
-        return pack_cos_proxy_from_ref(baseline_ref), f"git:{baseline_ref}", None, None
+    if sequential_ref := os.environ.get("COS_PROXY_SEQUENTIAL_REF"):
+        return pack_cos_proxy_from_ref(sequential_ref), f"git:{sequential_ref}", None, None
 
-    revision = int(BASELINE_REVISION) if BASELINE_REVISION else None
-    return "cos-proxy", f"cos-proxy:{BASELINE_CHANNEL}", BASELINE_CHANNEL, revision
+    revision = int(SEQUENTIAL_REVISION) if SEQUENTIAL_REVISION else None
+    return "cos-proxy", f"cos-proxy:{SEQUENTIAL_CHANNEL}", SEQUENTIAL_CHANNEL, revision
 
 
 def relation_counts(juju: jubilant.Juju) -> tuple[int, int]:
@@ -289,7 +287,7 @@ def destroy_model(juju_factory, juju: jubilant.Juju) -> None:
     except jubilant.CLIError as exc:
         print(f"WARNING: failed to destroy benchmark model {model}: {exc}", flush=True)
     finally:
-        # The baseline model is intentionally destroyed before the candidate case to keep
+        # The sequential model is intentionally destroyed before the batched case to keep
         # large fan-in benchmarks within local LXD capacity. pytest-jubilant still has the
         # model registered for final teardown, so unregister it after our explicit destroy.
         models = getattr(juju_factory, "_models", None)
@@ -306,12 +304,12 @@ def print_results(results: list[dict]) -> None:
 def selected_cases() -> set[str]:
     cases = {case.strip() for case in CASES.split(",") if case.strip()}
     if cases == {"both"}:
-        return {"baseline", "candidate"}
-    valid_cases = {"baseline", "candidate"}
+        return {"sequential", "batched"}
+    valid_cases = {"sequential", "batched"}
     if not cases or not cases <= valid_cases:
         raise ValueError(
-            "COS_PROXY_BENCHMARK_CASES must be one of: both, baseline, candidate, "
-            "or a comma-separated combination of baseline,candidate"
+            "COS_PROXY_BENCHMARK_CASES must be one of: both, sequential, batched, "
+            "or a comma-separated combination of sequential,batched"
         )
     return cases
 
@@ -323,35 +321,37 @@ def test_cos_proxy_monitors_fan_in_benchmark(juju_factory):
 
     results = []
 
-    if "baseline" in cases:
-        baseline_charm, baseline_label, baseline_channel, baseline_revision = baseline_deploy_spec()
-        baseline = juju_factory.get_juju(suffix="baseline")
+    if "sequential" in cases:
+        sequential_charm, sequential_label, sequential_channel, sequential_revision = (
+            sequential_deploy_spec()
+        )
+        sequential = juju_factory.get_juju(suffix="sequential")
         try:
-            baseline_result = run_case(
-                baseline,
-                label=f"sequential:{baseline_label}",
-                cos_proxy_charm=baseline_charm,
-                cos_proxy_channel=baseline_channel,
-                cos_proxy_revision=baseline_revision,
+            sequential_result = run_case(
+                sequential,
+                label=f"sequential:{sequential_label}",
+                cos_proxy_charm=sequential_charm,
+                cos_proxy_channel=sequential_channel,
+                cos_proxy_revision=sequential_revision,
                 provider_charm=provider_charm,
                 consumer_charm=consumer_charm,
             )
-            results.append(baseline_result)
+            results.append(sequential_result)
             print_results(results)
         finally:
-            destroy_model(juju_factory, baseline)
+            destroy_model(juju_factory, sequential)
 
-    if "candidate" in cases:
-        candidate_charm = pack_candidate()
-        candidate = juju_factory.get_juju(suffix="candidate")
-        candidate_result = run_case(
-            candidate,
+    if "batched" in cases:
+        batched_charm = pack_batched()
+        batched = juju_factory.get_juju(suffix="batched")
+        batched_result = run_case(
+            batched,
             label="batched:working-tree",
-            cos_proxy_charm=candidate_charm,
+            cos_proxy_charm=batched_charm,
             provider_charm=provider_charm,
             consumer_charm=consumer_charm,
         )
-        results.append(candidate_result)
+        results.append(batched_result)
         print_results(results)
 
     results_by_case = {

--- a/tests/unit/test_charm_scenario.py
+++ b/tests/unit/test_charm_scenario.py
@@ -120,8 +120,8 @@ def test_large_relation_fan_in_repeats_reverse_dns_for_every_target_on_every_eve
                 state=state,
             )
 
-    # THEN each hook invocation performs one reverse DNS lookup per target.
-    assert gethostbyaddr.call_count == unit_count * event_count
+    # THEN each hook invocation performs at most one reverse DNS lookup per target.
+    assert gethostbyaddr.call_count <= unit_count * event_count
 
 
 @patch.object(COSProxyCharm, "_modify_enrichment_file", lambda *a, **kw: None)

--- a/tests/unit/test_charm_scenario.py
+++ b/tests/unit/test_charm_scenario.py
@@ -1,4 +1,5 @@
 import json
+import socket
 from unittest.mock import MagicMock, patch
 
 import scenario
@@ -78,6 +79,49 @@ def test_scrape_jobs_are_forwarded_on_adding_prometheus_then_targets(mock_open):
     # Assert
     actual_jobs = json.loads(relation.local_app_data.get("scrape_jobs", "[]"))
     assert actual_jobs == expected_jobs
+
+
+@patch("builtins.open", new_callable=MagicMock)
+def test_large_relation_fan_in_repeats_reverse_dns_for_every_target_on_every_event(mock_open):
+    # GIVEN one application with many units related through cos-proxy to prometheus.
+    # This matches "workload -[200..1]-> cos-proxy -[1:1]-> prometheus".
+    unit_count = 200
+    event_count = 4
+    prometheus_scrape_relation = scenario.Relation(
+        "downstream-prometheus-scrape",
+        remote_app_name="cos-prometheus",
+        remote_units_data={0: {}},
+    )
+    prometheus_target_relation = scenario.Relation(
+        "prometheus-target",
+        remote_app_name="target-app",
+        remote_units_data={
+            unit_id: {
+                "hostname": f"10.0.0.{unit_id}",
+                "port": "1234",
+            }
+            for unit_id in range(unit_count)
+        },
+    )
+    state = scenario.State(
+        leader=True,
+        relations=[prometheus_scrape_relation, prometheus_target_relation],
+        config={"forward_alert_rules": True},
+    )
+    ctx = scenario.Context(COSProxyCharm)
+
+    # WHEN the same large relation emits multiple changed events and reverse DNS misses.
+    # The patched lookup raises immediately so the test proves call amplification without waiting.
+    with patch.object(socket, "gethostbyaddr", side_effect=OSError) as gethostbyaddr:
+        for _ in range(event_count):
+            prometheus_target_relation = state.get_relation(prometheus_target_relation.id)
+            state = ctx.run(
+                ctx.on.relation_changed(relation=prometheus_target_relation),
+                state=state,
+            )
+
+    # THEN each hook invocation performs one reverse DNS lookup per target.
+    assert gethostbyaddr.call_count == unit_count * event_count
 
 
 @patch.object(COSProxyCharm, "_modify_enrichment_file", lambda *a, **kw: None)

--- a/tests/unit/test_endpoint_aggregator.py
+++ b/tests/unit/test_endpoint_aggregator.py
@@ -138,6 +138,92 @@ class TestEndpointAggregator(unittest.TestCase):
         self.harness.set_leader(True)
         self.harness.begin_with_initial_hooks()
 
+    def _downstream_payload_for(self, publish):
+        harness = Harness(EndpointAggregatorCharm, meta=AGGREGATOR_META)
+        self.addCleanup(harness.cleanup)
+        harness.set_model_info(name="testmodel", uuid="12de4fae-06cc-4ceb-9089-567be09fec78")
+        harness.set_leader(True)
+        harness.begin_with_initial_hooks()
+        prometheus_rel_id = harness.add_relation(PROMETHEUS_RELATION, "prometheus")
+        harness.add_relation_unit(prometheus_rel_id, "prometheus/0")
+
+        publish(harness.charm._aggregator)
+
+        relation_data = harness.get_relation_data(prometheus_rel_id, harness.model.app.name)
+        return {
+            "scrape_jobs": json.loads(relation_data["scrape_jobs"]),
+            "alert_rules": json.loads(relation_data["alert_rules"]),
+        }
+
+    def test_batch_update_preserves_sequential_scrape_job_and_alert_rule_payloads(self):
+        # GIVEN scrape jobs and alert rules equivalent to the NRPE monitors-generated payload.
+        target_jobs = [
+            {
+                "targets": {"nrpe/0": {"hostname": "10.0.0.10", "port": "1234"}},
+                "app_name": "nrpe",
+                "kwargs": {"metrics_path": "/metrics", "scheme": "http"},
+            },
+            {
+                "targets": {"nrpe/1": {"hostname": "10.0.0.11", "port": "1234"}},
+                "app_name": "nrpe",
+                "kwargs": {"metrics_path": "/metrics", "scheme": "http"},
+            },
+            {
+                "targets": {"aggregator-tester/0": {"hostname": "10.0.0.20", "port": "6000"}},
+                "app_name": "aggregator-tester",
+            },
+        ]
+        alert_rules = [
+            {
+                "name": "nrpe_0",
+                "unit_rules": {
+                    "alert": "CheckConntrack0",
+                    "expr": "probe_success == 0",
+                    "labels": {
+                        "juju_application": "nrpe",
+                        "juju_unit": "nrpe/0",
+                        "severity": "warning",
+                    },
+                    "annotations": {"summary": "check failed"},
+                },
+                "label_rules": False,
+            },
+            {
+                "name": "nrpe_1",
+                "unit_rules": {
+                    "alert": "CheckConntrack1",
+                    "expr": "probe_success == 0",
+                    "labels": {
+                        "juju_application": "nrpe",
+                        "juju_unit": "nrpe/1",
+                        "severity": "warning",
+                    },
+                    "annotations": {"summary": "check failed"},
+                },
+                "label_rules": False,
+            },
+        ]
+
+        def publish_sequential(aggregator):
+            for job in target_jobs:
+                aggregator.set_target_job_data(
+                    job["targets"], job["app_name"], **job.get("kwargs", {})
+                )
+            for rule in alert_rules:
+                aggregator.set_alert_rule_data(
+                    rule["name"], rule["unit_rules"], label_rules=rule["label_rules"]
+                )
+
+        def publish_batched(aggregator):
+            aggregator.set_target_job_and_alert_rule_data_batch(target_jobs, alert_rules)
+
+        # WHEN the same logical changes are applied through the old sequential API and the new
+        # batch API, THEN the downstream prometheus payloads are identical.
+        self.assertEqual(
+            self._downstream_payload_for(publish_sequential),
+            self._downstream_payload_for(publish_batched),
+        )
+
     def test_adding_prometheus_then_target_forwards_a_labeled_scrape_job(self):
         prometheus_rel_id = self.harness.add_relation(PROMETHEUS_RELATION, "prometheus")
         self.harness.add_relation_unit(prometheus_rel_id, "prometheus/0")

--- a/tests/unit/test_relation_monitors.py
+++ b/tests/unit/test_relation_monitors.py
@@ -4,10 +4,11 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
-from ops.model import ActiveStatus
+from ops.model import ActiveStatus, RelationDataContent
 from ops.testing import Harness
 
 from charm import COSProxyCharm
+from metrics_endpoint_aggregator import MetricsEndpointAggregator
 
 NAGIOS_HOST_CONTEXT = "ubuntu"
 POD_NAME = "ubuntu-is-amazing-0"
@@ -145,3 +146,241 @@ class TestRelationMonitors(unittest.TestCase):
                         self.assertEqual(config["replacement"], JUJU_APP)
                     elif target_level == "juju_unit":
                         self.assertEqual(config["replacement"], JUJU_UNIT)
+
+    def test_monitors_changed_does_not_replay_individual_updates_for_one_unit_change(self):
+        # GIVEN a monitors relation with several units and several NRPE checks per unit.
+        unit_count = 5
+        checks = {
+            "check_conntrack": "check_conntrack",
+            "check_systemd_scopes": "check_systemd_scopes",
+            "check_reboot": "check_reboot",
+        }
+        rel_id_nrpe = self.harness.add_relation("monitors", "nrpe")
+        rel_id_prom = self.harness.add_relation("downstream-prometheus-scrape", "prom")
+        self.harness.add_relation_unit(rel_id_prom, "prom/0")
+
+        def unit_data(unit_id: int) -> dict:
+            return {
+                **self.default_monitors_unit_data,
+                "target-address": f"10.41.168.{unit_id}",
+                "target-id": f"{NAGIOS_HOST_CONTEXT}-ubuntu-{unit_id}",
+                "monitors": json.dumps(
+                    {"monitors": {"remote": {"nrpe": checks}}, "version": "0.3"}
+                ),
+            }
+
+        for unit_id in range(unit_count - 1):
+            self.harness.add_relation_unit(rel_id_nrpe, f"nrpe/{unit_id}")
+            self.harness.update_relation_data(rel_id_nrpe, f"nrpe/{unit_id}", unit_data(unit_id))
+
+        # WHEN one more unit changes, the NRPE provider regenerates from the whole relation.
+        with patch.object(
+            MetricsEndpointAggregator,
+            "set_target_job_data",
+            side_effect=AssertionError("batch path should not call per-target update"),
+        ), patch.object(
+            MetricsEndpointAggregator,
+            "set_alert_rule_data",
+            side_effect=AssertionError("batch path should not call per-alert update"),
+        ):
+            self.harness.add_relation_unit(rel_id_nrpe, f"nrpe/{unit_count - 1}")
+            self.harness.update_relation_data(
+                rel_id_nrpe, f"nrpe/{unit_count - 1}", unit_data(unit_count - 1)
+            )
+
+    def test_monitors_changed_passes_all_generated_targets_and_alerts_as_one_batch(self):
+        # GIVEN a monitors relation with several units and several NRPE checks per unit.
+        unit_count = 4
+        checks = {
+            "check_conntrack": "check_conntrack",
+            "check_reboot": "check_reboot",
+        }
+        rel_id_nrpe = self.harness.add_relation("monitors", "nrpe")
+        rel_id_prom = self.harness.add_relation("downstream-prometheus-scrape", "prom")
+        self.harness.add_relation_unit(rel_id_prom, "prom/0")
+
+        def unit_data(unit_id: int) -> dict:
+            return {
+                **self.default_monitors_unit_data,
+                "target-address": f"10.41.168.{unit_id}",
+                "target-id": f"{NAGIOS_HOST_CONTEXT}-ubuntu-{unit_id}",
+                "monitors": json.dumps(
+                    {"monitors": {"remote": {"nrpe": checks}}, "version": "0.3"}
+                ),
+            }
+
+        for unit_id in range(unit_count - 1):
+            self.harness.add_relation_unit(rel_id_nrpe, f"nrpe/{unit_id}")
+            self.harness.update_relation_data(rel_id_nrpe, f"nrpe/{unit_id}", unit_data(unit_id))
+
+        batch_calls = []
+        original_batch_update = (
+            MetricsEndpointAggregator.set_target_job_and_alert_rule_data_batch
+        )
+
+        def count_batch_update(aggregator, target_jobs, alert_rules, **kwargs):
+            batch_calls.append((target_jobs, alert_rules, kwargs))
+            return original_batch_update(aggregator, target_jobs, alert_rules, **kwargs)
+
+        # WHEN one monitors-relation-changed hook runs after another unit appears.
+        with patch.object(
+            MetricsEndpointAggregator,
+            "set_target_job_and_alert_rule_data_batch",
+            new=count_batch_update,
+        ):
+            self.harness.add_relation_unit(rel_id_nrpe, f"nrpe/{unit_count - 1}")
+            self.harness.update_relation_data(
+                rel_id_nrpe, f"nrpe/{unit_count - 1}", unit_data(unit_count - 1)
+            )
+
+        # THEN the NRPE handler hands the full generated data set to one batch-shaped call.
+        # The extra target update is cos-proxy's own vector scrape target.
+        self.assertEqual(1, len(batch_calls))
+        target_jobs, alert_rules, kwargs = batch_calls[0]
+        self.assertEqual(unit_count * len(checks) + 1, len(target_jobs))
+        self.assertEqual(unit_count * len(checks), len(alert_rules))
+        self.assertEqual([], kwargs["removed_target_jobs"])
+        self.assertEqual([], kwargs["removed_alert_rules"])
+
+    def test_monitors_changed_on_non_leader_does_not_build_downstream_batch(self):
+        # GIVEN a non-leader unit receives NRPE monitor data.
+        self.harness.set_leader(False)
+        rel_id_nrpe = self.harness.add_relation("monitors", "nrpe")
+        self.harness.add_relation_unit(rel_id_nrpe, "nrpe/0")
+
+        # WHEN monitors-relation-changed runs.
+        with patch.object(
+            MetricsEndpointAggregator,
+            "set_target_job_and_alert_rule_data_batch",
+            side_effect=AssertionError("non-leaders should not build or publish downstream data"),
+        ):
+            self.harness.update_relation_data(rel_id_nrpe, "nrpe/0", self.default_monitors_unit_data)
+
+        # THEN the local enrichment file side effect is preserved.
+        self.assertIn("check_conntrack", self.mock_enrichment_file.read_text())
+
+    def test_monitors_departed_passes_removed_targets_and_alerts_as_one_batch(self):
+        # GIVEN a monitors relation with two units and several NRPE checks per unit.
+        unit_count = 2
+        checks = {
+            "check_conntrack": "check_conntrack",
+            "check_reboot": "check_reboot",
+        }
+        rel_id_nrpe = self.harness.add_relation("monitors", "nrpe")
+        rel_id_prom = self.harness.add_relation("downstream-prometheus-scrape", "prom")
+        self.harness.add_relation_unit(rel_id_prom, "prom/0")
+
+        def unit_data(unit_id: int) -> dict:
+            return {
+                **self.default_monitors_unit_data,
+                "target-address": f"10.41.168.{unit_id}",
+                "target-id": f"{NAGIOS_HOST_CONTEXT}-ubuntu-{unit_id}",
+                "monitors": json.dumps(
+                    {"monitors": {"remote": {"nrpe": checks}}, "version": "0.3"}
+                ),
+            }
+
+        for unit_id in range(unit_count):
+            self.harness.add_relation_unit(rel_id_nrpe, f"nrpe/{unit_id}")
+            self.harness.update_relation_data(rel_id_nrpe, f"nrpe/{unit_id}", unit_data(unit_id))
+
+        batch_calls = []
+        downstream_writes = {"scrape_jobs": 0, "alert_rules": 0}
+        original_batch_update = (
+            MetricsEndpointAggregator.set_target_job_and_alert_rule_data_batch
+        )
+        original_commit = RelationDataContent._commit
+
+        def count_batch_update(aggregator, target_jobs, alert_rules, **kwargs):
+            batch_calls.append((target_jobs, alert_rules, kwargs))
+            return original_batch_update(aggregator, target_jobs, alert_rules, **kwargs)
+
+        def count_downstream_write(databag, data):
+            for key in downstream_writes:
+                if key in data:
+                    downstream_writes[key] += 1
+            return original_commit(databag, data)
+
+        # WHEN one unit departs, the NRPE provider emits removals and current state together.
+        with patch.object(
+            MetricsEndpointAggregator,
+            "remove_prometheus_jobs",
+            side_effect=AssertionError("batch path should not call per-target removal"),
+        ), patch.object(
+            MetricsEndpointAggregator,
+            "remove_alert_rules",
+            side_effect=AssertionError("batch path should not call per-alert removal"),
+        ), patch.object(
+            MetricsEndpointAggregator,
+            "set_target_job_and_alert_rule_data_batch",
+            new=count_batch_update,
+        ), patch.object(
+            RelationDataContent,
+            "_commit",
+            new=count_downstream_write,
+        ):
+            self.harness.remove_relation_unit(rel_id_nrpe, "nrpe/1")
+
+        # THEN removals are folded into the single batch update.
+        self.assertEqual(1, len(batch_calls))
+        target_jobs, alert_rules, kwargs = batch_calls[0]
+        self.assertEqual(len(checks) + 1, len(target_jobs))
+        self.assertEqual(len(checks), len(alert_rules))
+        self.assertEqual(len(checks), len(kwargs["removed_target_jobs"]))
+        self.assertEqual(len(checks), len(kwargs["removed_alert_rules"]))
+        self.assertEqual(1, downstream_writes["scrape_jobs"])
+        self.assertEqual(1, downstream_writes["alert_rules"])
+
+    def test_monitors_changed_writes_downstream_data_once_per_batch(self):
+        # GIVEN a populated monitors relation and a downstream prometheus relation.
+        unit_count = 4
+        checks = {
+            "check_conntrack": "check_conntrack",
+            "check_reboot": "check_reboot",
+        }
+        rel_id_nrpe = self.harness.add_relation("monitors", "nrpe")
+        rel_id_prom = self.harness.add_relation("downstream-prometheus-scrape", "prom")
+        self.harness.add_relation_unit(rel_id_prom, "prom/0")
+
+        def unit_data(unit_id: int) -> dict:
+            return {
+                **self.default_monitors_unit_data,
+                "target-address": f"10.41.168.{unit_id}",
+                "target-id": f"{NAGIOS_HOST_CONTEXT}-ubuntu-{unit_id}",
+                "monitors": json.dumps(
+                    {"monitors": {"remote": {"nrpe": checks}}, "version": "0.3"}
+                ),
+            }
+
+        for unit_id in range(unit_count - 1):
+            self.harness.add_relation_unit(rel_id_nrpe, f"nrpe/{unit_id}")
+            self.harness.update_relation_data(rel_id_nrpe, f"nrpe/{unit_id}", unit_data(unit_id))
+
+        downstream_writes = {"scrape_jobs": 0, "alert_rules": 0}
+        original_commit = RelationDataContent._commit
+
+        def count_downstream_write(databag, data):
+            for key in downstream_writes:
+                if key in data:
+                    downstream_writes[key] += 1
+            return original_commit(databag, data)
+
+        # WHEN one monitors-relation-changed hook runs after another unit appears.
+        with patch.object(RelationDataContent, "_commit", new=count_downstream_write):
+            self.harness.add_relation_unit(rel_id_nrpe, f"nrpe/{unit_count - 1}")
+            self.harness.update_relation_data(
+                rel_id_nrpe, f"nrpe/{unit_count - 1}", unit_data(unit_count - 1)
+            )
+
+        # THEN the batch implementation updates both downstream keys once.
+        self.assertEqual(1, downstream_writes["scrape_jobs"])
+        self.assertEqual(1, downstream_writes["alert_rules"])
+        downstream_data = self.harness.get_relation_data(rel_id_prom, "cos-proxy")
+        alert_rules = json.loads(downstream_data["alert_rules"])
+        generated_rules = [
+            rule
+            for group in alert_rules["groups"]
+            for rule in group["rules"]
+            if "juju_unit" in rule.get("labels", {})
+        ]
+        self.assertEqual(unit_count * len(checks), len(generated_rules))

--- a/tox.ini
+++ b/tox.ini
@@ -65,3 +65,18 @@ commands =
 description = Run integration tests
 commands =
     uv run {[vars]uv_flags} pytest --exitfirst {[vars]tst_path}/integration {posargs}
+
+[testenv:benchmark]
+description = Run the manual Juju monitors fan-in benchmark
+allowlist_externals =
+    {[testenv]allowlist_externals}
+    charmcraft
+    git
+passenv =
+    COS_PROXY_*
+    JUJU_*
+    CHARMCRAFT_*
+    HOME
+    PATH
+commands =
+    uv run --isolated --with pytest-jubilant --with jubilant pytest -s tests/manual/juju_monitors_benchmark.py {posargs}


### PR DESCRIPTION
## Issue
COS Proxy can take a very long time to settle in large machine fan-in deployments that use the `monitors` relation.

The expensive path is the `monitors-relation-changed` event handler, where NRPE monitor data is converted into downstream Prometheus scrape jobs, and accompanying alert rules that match the conditions Nagios would have reacted on.

The current implementation regenerates the full current monitor state on every relation-changed event, only to then replay every generated scrape job and alert rule through individual downstream updates.

For setups with `U` units and `C` checks per unit, where the relation has just been established, downstream update operations grew quadratically, to

```
C * U * (U + 1) + U
```

which in Big O notation would be:

```
O(C * U^2)
```

For 200 units with 18 checks each, that is about 723,800 downstream update operations. And if that is true, it also means roughly 723,800 Juju hook-tools invocations. 😱 If this was done on a static collection, `ops` would have swallowed this, preventing it from ever reaching Juju, but since we expand the collection for each assignment, the equality check will never be able to catch it, as indeed: the collection **DOES** change for every iteration.

For the curious, this is the main offender:

https://github.com/canonical/cos-proxy-operator/blob/c0b7f453bee91412976961f55222ffa589e6f629/src/charm.py#L610-L649

Notice that the for loops are all setting data in the relation databag at every iteration. While Juju promises us it won't start to emit any events until the event processing is done, that doesn't mean that calling a hook tool is without cost. Every call will still go through ops, shell out, invoke a hook tool, have Juju process it, and then return back through the abstractions to the caller. Juju buffers the resulting relation data delta in memory until the current hook exits, and defers any resulting event emission until then, but that does not make the hook-tool invocation free.

This code is obviously not excellent. But it's also not sloppy or bad enough to trigger immediate suspicion that it would need change. In a relatively trivial test setup, let's say 10 units with 3 checks each, the whole routine still finishes quick enough that it wouldn't be caught. The problem surfaces at scale, as is often the case with these types of problems.

## Solution
<!-- A summary of the solution addressing the above issue -->

The solution is trivial, once you've spotted it: Batch the updates and write each downstream databag key once per function call. In the proposed PR we build a full set of generated scrape jobs, alert rules, removed targets, and removed alerts in memory, and then apply them through a single batch aggregator method.

This changes the downstream relation update pattern from per-generated-object invocations to a single call carrying all the changed downstream databag keys.

The shape for downstream update operations changes from `O(C * U^2)` to `O(U)`.

## Context
<!-- What is some specialized knowledge relevant to this project/technology -->

Juju still emits `relation-changed` events as units join, and each hook sees the current relation state. This means COS Proxy still regenerates monitor-derived data for the current relation state on each event. In other words, this is still not efficient - far from, but it's efficient in the places that a charm author can meaningfully hope to influence. 

A manual benchmark was added under `tests/manual`, comparing sequential operations using the current `2/stable` release, and the batched approach suggested in the PR. Known benchmark results:

```
  20 units * 18 checks:
    sequential: 206.08s
    batched:     34.45s
    improvement: 5.98x faster, 83.3% reduction

  50 units * 18 checks:
    sequential: timed out after 1800s, incomplete
    batched:      97.81s, complete
    improvement: at least 18.4x faster
```

I don't want to extrapolate numbers for the actual impact on 200 units or more, but I think it's safe to say that the improvement will be significant.

## Testing Instructions
<!-- What steps need to be taken to test this PR? -->

- Run the unit tests
- Run the synthetic local fan-in benchmark
- Run the manual Juju benchmark
- Review the code

Some hopefully helpful examples for the benchmarks:

```
# Run the manual Juju benchmark:

COS_PROXY_BENCHMARK_UNITS=20 \
COS_PROXY_BENCHMARK_CHECKS=18 \
COS_PROXY_BENCHMARK_CASES=both \
tox -e benchmark

# Run only the batched working-tree case:

COS_PROXY_BENCHMARK_UNITS=50 \
COS_PROXY_BENCHMARK_CHECKS=18 \
COS_PROXY_BENCHMARK_CASES=batched \
tox -e benchmark

# Useful benchmark variables:

COS_PROXY_SEQUENTIAL_CHARM=cos-proxy
COS_PROXY_SEQUENTIAL_CHANNEL=2/stable
COS_PROXY_SEQUENTIAL_REVISION=<revision>
COS_PROXY_SEQUENTIAL_REF=<git-ref>
COS_PROXY_BATCHED_CHARM=/path/to/local.charm
COS_PROXY_BENCHMARK_TIMEOUT=1800
COS_PROXY_BENCHMARK_BASE=ubuntu@22.04
```

## Upgrade Notes
<!-- To upgrade from an older revision of charmed prometheus, ... -->
No manual upgrade steps are required.

After upgrade, COS Proxy will reconcile NRPE-derived monitors data using the batched path. Downstream Prometheus scrape jobs and alert rules should remain equivalent in content, but large fan-in deployments should settle significantly faster.