### PR TITLE
test: stabilize tracing integration test wait condition for opentelemetry-collector (backport #242)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __pycache__/
 *.py[cod]
 
 nrpe_exporter-*
+*.egg-info/

--- a/tests/integration/test_charm_tracing.py
+++ b/tests/integration/test_charm_tracing.py
@@ -32,6 +32,16 @@ def _trigger_update_status_event(juju: Juju, unit_name: str):
     )
 
 
+def _otel_collector_ready(status):
+    """Return True once the collector reaches a stable post-integration status."""
+    app = status.apps.get(OTEL_COLLECTOR_APP_NAME)
+    if app is None:
+        return False
+    if app.app_status is None:
+        return False
+    return app.app_status.current in {"waiting", "blocked"}
+
+
 @pytest.mark.setup
 @given("a cos-proxy charm is deployed")
 def test_deploy_cos_proxy(juju: Juju, charm):
@@ -65,7 +75,7 @@ def test_integrate_cos_agent(juju: Juju):
         OTEL_COLLECTOR_APP_NAME + ":cos-agent",
     )
     juju.wait(
-        lambda status: jubilant.all_blocked(status, OTEL_COLLECTOR_APP_NAME),
+        _otel_collector_ready,
         timeout=10 * 60,
         delay=10,
         successes=3,


### PR DESCRIPTION
Backport of #242 to `track/3.0`.

Aligns the `test_integrate_cos_agent` wait condition with the current `opentelemetry-collector` lifecycle: readiness is now accepted on either `waiting` or `blocked`, since the collector commonly stabilizes as `waiting` (`installing agent`) in CI, which caused the 600s timeout.

## Changes

- Add `_otel_collector_ready` predicate with defensive null checks in `tests/integration/test_charm_tracing.py`.
- Replace the strict `all_blocked` wait for `opentelemetry-collector` with the new predicate.
- Ignore `*.egg-info/` in `.gitignore`.