### PR TITLE
feat: Integration tests with real charms

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -192,6 +192,7 @@ class COSProxyCharm(CharmBase):
             extra_alert_groups=self._get_stored_alert_groups,
             dashboard_dirs=[COS_PROXY_DASHBOARDS_DIR, DASHBOARDS_DIR],
             refresh_events=[
+                self.on.config_changed,
                 self.on.prometheus_target_relation_changed,
                 self.on.prometheus_target_relation_broken,
                 self.on.prometheus_rules_relation_changed,
@@ -382,11 +383,13 @@ class COSProxyCharm(CharmBase):
         return _type_convert_stored(self.metrics_aggregator._stored.jobs)  # pyright: ignore
 
     def _get_stored_alert_groups(self) -> Dict[str, Any]:
-        """Return the alert rules from stored state.
+        """Return the alert rules from stored state, respecting the forward_alert_rules config.
 
         The source of truth for alert rules exists in self.metrics_aggregator._stored.alert_rules
         and should be updated elsewhere accordingly to populate cos-agent relation data.
         """
+        if not self.config.get("forward_alert_rules", True):
+            return {"groups": []}
         return {"groups":_type_convert_stored(self.metrics_aggregator._stored.alert_rules)}  # pyright: ignore
 
     def _dashboards_relation_joined(self, _):

--- a/tests/integration/assertions.py
+++ b/tests/integration/assertions.py
@@ -7,10 +7,6 @@ from typing import List
 from conftest import OTEL_COLLECTOR_APP_NAME
 from jubilant import CLIError, Juju
 
-# A rule name unique to telegraf's built-in alert rules.
-# telegraf rev75 sends exactly these 6 rules via prometheus-rules:
-# rule_cpu_usage.j2 (CPU_Usage), rule_diskfull.j2 (DiskFull), rule_mem.j2,
-# rule_disk_ro.j2, rule_packetdrops.j2, rule_predict_disk_space.j2 (ThreeDayPredictedDiskOutage).
 TELEGRAF_RULE_MARKER = "ThreeDayPredictedDiskOutage"
 
 

--- a/tests/integration/assertions.py
+++ b/tests/integration/assertions.py
@@ -7,6 +7,10 @@ from typing import List
 from conftest import OTEL_COLLECTOR_APP_NAME
 from jubilant import CLIError, Juju
 
+# A rule name that is unique to telegraf's built-in alert rules
+# (see: tests/integration README, telegraf rev75 ships CPU_Usage, DiskFull, etc.)
+TELEGRAF_RULE_MARKER = "CPU_Usage"
+
 
 def assert_pattern_in_snap_logs(juju: Juju, grep_filters: List[str]):
     """Assert that patterns appear in the opentelemetry-collector snap logs."""
@@ -26,3 +30,48 @@ def assert_pattern_in_snap_logs(juju: Juju, grep_filters: List[str]):
         )
 
     assert otelcol_logs, f"Logs matching {grep_filters!r} not found in {OTEL_COLLECTOR_APP_NAME}/0"
+
+
+def assert_pattern_absent_in_otelcol_config(juju: Juju, pattern: str):
+    """Assert that a pattern does NOT appear in the otelcol generated config file."""
+    config_path = f"/etc/otelcol/config.d/{OTEL_COLLECTOR_APP_NAME}_0.yaml"
+    try:
+        config = juju.ssh(
+            f"{OTEL_COLLECTOR_APP_NAME}/0",
+            command=f"sudo cat {config_path} | grep '{pattern}' || true",
+        )
+    except CLIError:
+        return  # File absent = pattern absent = success
+    assert not config.strip(), (
+        f"Pattern {pattern!r} was unexpectedly found in otelcol config after relation removal"
+    )
+
+
+def get_alert_rule_files_in_otelcol(juju: Juju) -> str:
+    """Return a string of all alert rule file paths in otelcol's charm directory."""
+    unit = f"{OTEL_COLLECTOR_APP_NAME}/0"
+    unit_dir = f"unit-{OTEL_COLLECTOR_APP_NAME.replace('-', '-')}-0"
+    rules_dir = f"/var/lib/juju/agents/{unit_dir}/charm/prometheus_alert_rules"
+    try:
+        return juju.ssh(unit, command=f"find {rules_dir} -type f 2>/dev/null || true")
+    except CLIError:
+        return ""
+
+
+def get_alert_rules_content_in_otelcol(juju: Juju, pattern: str) -> str:
+    """Return lines matching pattern in the content of otelcol's alert rule files.
+
+    Uses grep -r over the prometheus_alert_rules directory so callers can test for
+    the presence or absence of specific rule names that are unique to telegraf
+    (e.g. ``CPU_Usage``, ``DiskFull``).
+    """
+    unit = f"{OTEL_COLLECTOR_APP_NAME}/0"
+    unit_dir = f"unit-{OTEL_COLLECTOR_APP_NAME.replace('-', '-')}-0"
+    rules_dir = f"/var/lib/juju/agents/{unit_dir}/charm/prometheus_alert_rules"
+    try:
+        return juju.ssh(
+            unit,
+            command=f"grep -r '{pattern}' {rules_dir} 2>/dev/null || true",
+        )
+    except CLIError:
+        return ""

--- a/tests/integration/assertions.py
+++ b/tests/integration/assertions.py
@@ -7,9 +7,11 @@ from typing import List
 from conftest import OTEL_COLLECTOR_APP_NAME
 from jubilant import CLIError, Juju
 
-# A rule name that is unique to telegraf's built-in alert rules
-# (see: tests/integration README, telegraf rev75 ships CPU_Usage, DiskFull, etc.)
-TELEGRAF_RULE_MARKER = "CPU_Usage"
+# A rule name unique to telegraf's built-in alert rules.
+# telegraf rev75 sends exactly these 6 rules via prometheus-rules:
+# rule_cpu_usage.j2 (CPU_Usage), rule_diskfull.j2 (DiskFull), rule_mem.j2,
+# rule_disk_ro.j2, rule_packetdrops.j2, rule_predict_disk_space.j2 (ThreeDayPredictedDiskOutage).
+TELEGRAF_RULE_MARKER = "ThreeDayPredictedDiskOutage"
 
 
 def assert_pattern_in_snap_logs(juju: Juju, grep_filters: List[str]):
@@ -38,10 +40,13 @@ def assert_pattern_absent_in_otelcol_config(juju: Juju, pattern: str):
     try:
         config = juju.ssh(
             f"{OTEL_COLLECTOR_APP_NAME}/0",
-            command=f"sudo cat {config_path} | grep '{pattern}' || true",
+            command=f"cat {config_path} | grep '{pattern}' || true",
         )
-    except CLIError:
-        return  # File absent = pattern absent = success
+    except CLIError as e:
+        raise AssertionError(
+            f"Config file {config_path} not found on {OTEL_COLLECTOR_APP_NAME}/0 "
+            f"(wrong unit, or charm is mid-hook?): {e}"
+        ) from e
     assert not config.strip(), (
         f"Pattern {pattern!r} was unexpectedly found in otelcol config after relation removal"
     )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -29,37 +29,17 @@ TELEGRAF_BASE = "ubuntu@22.04"
 OTELCOL_CHANNEL = "dev/edge"
 
 
-def get_otelcol_charm() -> str | None:
-    """Return a local path to the otelcol charm, or None to deploy from charmhub."""
-    if charm_path := os.getenv("OTELCOL_CHARM_PATH"):
-        resolved = str(Path(charm_path).resolve())
-        logger.info("using otelcol charm from env: %s", resolved)
-        return resolved
-    return None
-
-
 def deploy_otelcol(juju: jubilant.Juju, **config_kwargs):
-    """Deploy opentelemetry-collector from a local file or charmhub.
+    """Deploy opentelemetry-collector from charmhub.
 
-    Keyword arguments are passed as the ``config`` dict.  If the env var
-    ``OTELCOL_CHARM_PATH`` is set, that local charm file is used; otherwise
-    the charm is resolved from charmhub using ``OTELCOL_CHANNEL``.
+    Keyword arguments are passed as the ``config`` dict.
     """
-    local_path = get_otelcol_charm()
-    if local_path:
-        juju.deploy(
-            local_path,
-            OTEL_COLLECTOR_APP_NAME,
-            base=APP_BASE,
-            config=config_kwargs if config_kwargs else None,
-        )
-    else:
-        juju.deploy(
-            OTEL_COLLECTOR_APP_NAME,
-            channel=OTELCOL_CHANNEL,
-            base=APP_BASE,
-            config=config_kwargs if config_kwargs else None,
-        )
+    juju.deploy(
+        OTEL_COLLECTOR_APP_NAME,
+        channel=OTELCOL_CHANNEL,
+        base=APP_BASE,
+        config=config_kwargs if config_kwargs else None,
+    )
 
 
 def get_system_arch() -> str:
@@ -106,7 +86,7 @@ def patch_update_status_interval(juju: jubilant.Juju):
     juju.model_config(reset="update-status-hook-interval")
 
 
-@retry(stop=stop_after_attempt(2), wait=wait_fixed(10))
+@retry(stop=stop_after_attempt(30), wait=wait_fixed(10))
 def patch_otel_collector_log_level(juju: jubilant.Juju, unit_no: int = 0):
     """Patch the collector's log level to INFO for debug exporter inspection."""
     juju.ssh(
@@ -121,8 +101,7 @@ def patch_otel_collector_log_level(juju: jubilant.Juju, unit_no: int = 0):
 def juju():
     """Juju instance with a temporary model for testing."""
     keep_models: bool = os.environ.get("KEEP_MODELS") is not None
-    controller: str | None = os.environ.get("JUJU_CONTROLLER")
-    with jubilant.temp_model(keep=keep_models, controller=controller) as juju:
+    with jubilant.temp_model(keep=keep_models) as juju:
         juju.cli("set-model-constraints", f"arch={get_system_arch()}")
         yield juju
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -23,6 +23,43 @@ APP_NAME = "cos-proxy"
 APP_BASE = "ubuntu@24.04"
 OTEL_COLLECTOR_APP_NAME = "opentelemetry-collector"
 COS_CHANNEL = "2/edge"
+TELEGRAF_APP_NAME = "telegraf"
+UBUNTU_APP_NAME = "ubuntu"
+TELEGRAF_BASE = "ubuntu@22.04"
+OTELCOL_CHANNEL = "dev/edge"
+
+
+def get_otelcol_charm() -> str | None:
+    """Return a local path to the otelcol charm, or None to deploy from charmhub."""
+    if charm_path := os.getenv("OTELCOL_CHARM_PATH"):
+        resolved = str(Path(charm_path).resolve())
+        logger.info("using otelcol charm from env: %s", resolved)
+        return resolved
+    return None
+
+
+def deploy_otelcol(juju: jubilant.Juju, **config_kwargs):
+    """Deploy opentelemetry-collector from a local file or charmhub.
+
+    Keyword arguments are passed as the ``config`` dict.  If the env var
+    ``OTELCOL_CHARM_PATH`` is set, that local charm file is used; otherwise
+    the charm is resolved from charmhub using ``OTELCOL_CHANNEL``.
+    """
+    local_path = get_otelcol_charm()
+    if local_path:
+        juju.deploy(
+            local_path,
+            OTEL_COLLECTOR_APP_NAME,
+            base=APP_BASE,
+            config=config_kwargs if config_kwargs else None,
+        )
+    else:
+        juju.deploy(
+            OTEL_COLLECTOR_APP_NAME,
+            channel=OTELCOL_CHANNEL,
+            base=APP_BASE,
+            config=config_kwargs if config_kwargs else None,
+        )
 
 
 def get_system_arch() -> str:
@@ -84,7 +121,8 @@ def patch_otel_collector_log_level(juju: jubilant.Juju, unit_no: int = 0):
 def juju():
     """Juju instance with a temporary model for testing."""
     keep_models: bool = os.environ.get("KEEP_MODELS") is not None
-    with jubilant.temp_model(keep=keep_models) as juju:
+    controller: str | None = os.environ.get("JUJU_CONTROLLER")
+    with jubilant.temp_model(keep=keep_models, controller=controller) as juju:
         juju.cli("set-model-constraints", f"arch={get_system_arch()}")
         yield juju
 
@@ -93,8 +131,9 @@ def juju():
 def charm():
     """Charm used for integration testing."""
     if charm_path := os.getenv("CHARM_PATH"):
-        logger.info("using charm from env: %s", charm_path)
-        return charm_path
+        resolved = str(Path(charm_path).resolve())
+        logger.info("using charm from env: %s", resolved)
+        return resolved
 
     arch = get_system_arch()
     charm_file = REPO_ROOT / f"cos-proxy_ubuntu@24.04-{arch}.charm"

--- a/tests/integration/test_alert_rules.py
+++ b/tests/integration/test_alert_rules.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Integration tests for alert rule propagation: telegraf → cos-proxy → otelcol."""
+
+import jubilant
+import pytest
+from assertions import TELEGRAF_RULE_MARKER, get_alert_rules_content_in_otelcol
+from conftest import (
+    APP_NAME,
+    OTEL_COLLECTOR_APP_NAME,
+    TELEGRAF_APP_NAME,
+    TELEGRAF_BASE,
+    UBUNTU_APP_NAME,
+    deploy_otelcol,
+)
+from jubilant import Juju
+from tenacity import retry, stop_after_attempt, wait_fixed
+
+pytestmark = pytest.mark.usefixtures("patch_update_status_interval")
+
+
+def test_deploy_cos_proxy(juju: Juju, charm: str):
+    """Deploy cos-proxy. Expect BlockedStatus: no upstream or downstream relations yet."""
+    juju.deploy(charm, APP_NAME)
+    juju.wait(
+        lambda status: jubilant.all_blocked(status, APP_NAME),
+        timeout=10 * 60,
+        delay=10,
+        successes=3,
+    )
+
+
+def test_deploy_otelcol_and_integrate(juju: Juju):
+    """Deploy otelcol and integrate with cos-proxy via cos-agent.
+
+    No debug exporter needed here — alert rule verification uses filesystem checks,
+    not snap log grepping.
+    """
+    deploy_otelcol(juju)
+    juju.integrate(
+        f"{APP_NAME}:cos-agent",
+        f"{OTEL_COLLECTOR_APP_NAME}:cos-agent",
+    )
+    juju.wait(
+        lambda status: jubilant.all_blocked(status, APP_NAME),
+        timeout=10 * 60,
+        delay=10,
+        successes=3,
+    )
+
+
+def test_deploy_telegraf_and_integrate(juju: Juju):
+    """Deploy ubuntu + telegraf, integrate telegraf's alert rules with cos-proxy.
+
+    Uses the prometheus-rules relation (interface: prometheus-rules), which carries
+    raw Prometheus alert rule YAML groups from telegraf to cos-proxy.
+    """
+    juju.deploy(UBUNTU_APP_NAME, channel="latest/stable", base=TELEGRAF_BASE)
+    juju.deploy(TELEGRAF_APP_NAME, channel="latest/stable")
+    juju.integrate(f"{TELEGRAF_APP_NAME}:juju-info", f"{UBUNTU_APP_NAME}:juju-info")
+    juju.integrate(
+        f"{APP_NAME}:prometheus-rules",
+        f"{TELEGRAF_APP_NAME}:prometheus-rules",
+    )
+    juju.wait(
+        lambda status: jubilant.all_active(status, APP_NAME),
+        error=jubilant.any_error,
+        timeout=25 * 60,
+        delay=10,
+        successes=3,
+    )
+
+
+@retry(stop=stop_after_attempt(20), wait=wait_fixed(15))
+def test_alert_rules_appear_in_otelcol(juju: Juju):
+    """Verify that telegraf's alert rules appear in otelcol's prometheus_alert_rules directory.
+
+    cos-proxy reads alert rule YAML from the prometheus-rules relation databag,
+    labels them with Juju topology, and writes them to the cos-agent databag.
+    otelcol then writes them to disk under its charm's prometheus_alert_rules/ directory.
+
+    The alert rules file is named after cos-proxy's Juju topology (juju_<model>_<uuid>_cos-proxy.rules).
+    We verify presence by grepping for a telegraf-specific rule name (TELEGRAF_RULE_MARKER)
+    inside the file content, not by the filename alone.
+    """
+    content = get_alert_rules_content_in_otelcol(juju, TELEGRAF_RULE_MARKER)
+    assert content.strip(), (
+        f"Expected telegraf rule marker {TELEGRAF_RULE_MARKER!r} in otelcol alert rules but got nothing"
+    )
+
+
+def test_forward_alert_rules_false(juju: Juju):
+    """Verify that setting forward_alert_rules=false clears alert rules from otelcol.
+
+    This config option on cos-proxy suppresses rule forwarding to all downstream sinks.
+    otelcol should remove the rule files from its prometheus_alert_rules/ directory
+    once it processes the updated cos-agent databag.
+    """
+    juju.config(APP_NAME, {"forward_alert_rules": "false"})
+    juju.wait(
+        lambda status: jubilant.all_active(status, APP_NAME),
+        error=jubilant.any_error,
+        timeout=5 * 60,
+        delay=10,
+        successes=3,
+    )
+
+    @retry(stop=stop_after_attempt(20), wait=wait_fixed(10))
+    def _assert_rules_gone():
+        content = get_alert_rules_content_in_otelcol(juju, TELEGRAF_RULE_MARKER)
+        assert not content.strip(), (
+            f"Expected telegraf rule {TELEGRAF_RULE_MARKER!r} to be absent but found:\n{content}"
+        )
+
+    _assert_rules_gone()
+
+
+def test_forward_alert_rules_true(juju: Juju):
+    """Verify that re-enabling forward_alert_rules=true restores alert rules in otelcol."""
+    juju.config(APP_NAME, {"forward_alert_rules": "true"})
+    juju.wait(
+        lambda status: jubilant.all_active(status, APP_NAME),
+        error=jubilant.any_error,
+        timeout=5 * 60,
+        delay=10,
+        successes=3,
+    )
+
+    @retry(stop=stop_after_attempt(20), wait=wait_fixed(10))
+    def _assert_rules_back():
+        content = get_alert_rules_content_in_otelcol(juju, TELEGRAF_RULE_MARKER)
+        assert content.strip(), (
+            f"Expected telegraf rule {TELEGRAF_RULE_MARKER!r} to return but got nothing"
+        )
+
+    _assert_rules_back()
+
+
+def test_remove_telegraf_relation(juju: Juju):
+    """Remove the prometheus-rules relation between cos-proxy and telegraf."""
+    juju.remove_relation(
+        f"{APP_NAME}:prometheus-rules",
+        f"{TELEGRAF_APP_NAME}:prometheus-rules",
+    )
+    juju.wait(
+        lambda status: jubilant.all_blocked(status, APP_NAME),
+        timeout=10 * 60,
+        delay=10,
+        successes=3,
+    )
+
+
+@retry(stop=stop_after_attempt(20), wait=wait_fixed(10))
+def test_alert_rules_absent_from_otelcol(juju: Juju):
+    """Verify that telegraf's alert rules are removed from otelcol after relation removal."""
+    content = get_alert_rules_content_in_otelcol(juju, TELEGRAF_RULE_MARKER)
+    assert not content.strip(), (
+        f"Expected telegraf rule {TELEGRAF_RULE_MARKER!r} to be absent after removal but found:\n{content}"
+    )

--- a/tests/integration/test_alert_rules.py
+++ b/tests/integration/test_alert_rules.py
@@ -33,11 +33,7 @@ def test_deploy_cos_proxy(juju: Juju, charm: str):
 
 
 def test_deploy_otelcol_and_integrate(juju: Juju):
-    """Deploy otelcol and integrate with cos-proxy via cos-agent.
-
-    No debug exporter needed here — alert rule verification uses filesystem checks,
-    not snap log grepping.
-    """
+    """Deploy otelcol and integrate with cos-proxy via cos-agent."""
     deploy_otelcol(juju)
     juju.integrate(
         f"{APP_NAME}:cos-agent",
@@ -52,11 +48,7 @@ def test_deploy_otelcol_and_integrate(juju: Juju):
 
 
 def test_deploy_telegraf_and_integrate(juju: Juju):
-    """Deploy ubuntu + telegraf, integrate telegraf's alert rules with cos-proxy.
-
-    Uses the prometheus-rules relation (interface: prometheus-rules), which carries
-    raw Prometheus alert rule YAML groups from telegraf to cos-proxy.
-    """
+    """Deploy ubuntu + telegraf, integrate telegraf's alert rules with cos-proxy."""
     juju.deploy(UBUNTU_APP_NAME, channel="latest/stable", base=TELEGRAF_BASE)
     juju.deploy(TELEGRAF_APP_NAME, channel="latest/stable")
     juju.integrate(f"{TELEGRAF_APP_NAME}:juju-info", f"{UBUNTU_APP_NAME}:juju-info")
@@ -75,16 +67,7 @@ def test_deploy_telegraf_and_integrate(juju: Juju):
 
 @retry(stop=stop_after_attempt(20), wait=wait_fixed(15))
 def test_alert_rules_appear_in_otelcol(juju: Juju):
-    """Verify that telegraf's alert rules appear in otelcol's prometheus_alert_rules directory.
-
-    cos-proxy reads alert rule YAML from the prometheus-rules relation databag,
-    labels them with Juju topology, and writes them to the cos-agent databag.
-    otelcol then writes them to disk under its charm's prometheus_alert_rules/ directory.
-
-    The alert rules file is named after cos-proxy's Juju topology (juju_<model>_<uuid>_cos-proxy.rules).
-    We verify presence by grepping for a telegraf-specific rule name (TELEGRAF_RULE_MARKER)
-    inside the file content, not by the filename alone.
-    """
+    """Verify that telegraf's alert rules appear in otelcol's prometheus_alert_rules directory."""
     content = get_alert_rules_content_in_otelcol(juju, TELEGRAF_RULE_MARKER)
     assert content.strip(), (
         f"Expected telegraf rule marker {TELEGRAF_RULE_MARKER!r} in otelcol alert rules but got nothing"
@@ -92,12 +75,7 @@ def test_alert_rules_appear_in_otelcol(juju: Juju):
 
 
 def test_forward_alert_rules_false(juju: Juju):
-    """Verify that setting forward_alert_rules=false clears alert rules from otelcol.
-
-    This config option on cos-proxy suppresses rule forwarding to all downstream sinks.
-    otelcol should remove the rule files from its prometheus_alert_rules/ directory
-    once it processes the updated cos-agent databag.
-    """
+    """Verify that setting forward_alert_rules=false clears alert rules from otelcol."""
     juju.config(APP_NAME, {"forward_alert_rules": "false"})
     juju.wait(
         lambda status: jubilant.all_active(status, APP_NAME),

--- a/tests/integration/test_nothing.py
+++ b/tests/integration/test_nothing.py
@@ -1,4 +1,0 @@
-# https://github.com/canonical/observability/issues/304
-
-def test_nothing():
-    pass

--- a/tests/integration/test_scrape_jobs.py
+++ b/tests/integration/test_scrape_jobs.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Integration tests for scrape job propagation: telegraf → cos-proxy → otelcol."""
+
+import jubilant
+import pytest
+from assertions import assert_pattern_absent_in_otelcol_config, assert_pattern_in_snap_logs
+from conftest import (
+    APP_NAME,
+    OTEL_COLLECTOR_APP_NAME,
+    TELEGRAF_APP_NAME,
+    TELEGRAF_BASE,
+    UBUNTU_APP_NAME,
+    deploy_otelcol,
+    patch_otel_collector_log_level,
+)
+from jubilant import Juju
+from tenacity import retry, stop_after_attempt, wait_fixed
+
+pytestmark = pytest.mark.usefixtures("patch_update_status_interval")
+
+
+def _otelcol_ready(status) -> bool:
+    """Return True once otelcol has finished installing and reached a stable status."""
+    app = status.apps.get(OTEL_COLLECTOR_APP_NAME)
+    if app is None:
+        return False
+    if app.app_status is None:
+        return False
+    return app.app_status.current in {"waiting", "blocked", "active"}
+
+
+def test_deploy_cos_proxy(juju: Juju, charm: str):
+    """Deploy cos-proxy. Expect BlockedStatus: no upstream or downstream relations yet."""
+    juju.deploy(charm, APP_NAME)
+    juju.wait(
+        lambda status: jubilant.all_blocked(status, APP_NAME),
+        timeout=10 * 60,
+        delay=10,
+        successes=3,
+    )
+
+
+def test_deploy_otelcol_and_integrate(juju: Juju):
+    """Deploy otelcol with metrics debug exporter, integrate with cos-proxy via cos-agent.
+
+    otelcol is the sink for scrape jobs emitted by cos-proxy. The debug exporter writes
+    scraped metrics to snap logs, allowing grep-based verification.
+
+    cos-proxy remains in BlockedStatus after this step: it has a downstream sink
+    (cos-agent) but no upstream source yet.
+    """
+    deploy_otelcol(juju, debug_exporter_for_metrics=True)
+    juju.integrate(
+        f"{APP_NAME}:cos-agent",
+        f"{OTEL_COLLECTOR_APP_NAME}:cos-agent",
+    )
+    juju.wait(
+        _otelcol_ready,
+        timeout=10 * 60,
+        delay=10,
+        successes=3,
+    )
+    juju.wait(
+        lambda status: jubilant.all_blocked(status, APP_NAME),
+        timeout=10 * 60,
+        delay=10,
+        successes=3,
+    )
+    patch_otel_collector_log_level(juju)
+
+
+def test_deploy_telegraf_and_integrate(juju: Juju):
+    """Deploy ubuntu + telegraf, integrate telegraf's metrics endpoint with cos-proxy.
+
+    After this step:
+    - cos-proxy has both an upstream source (telegraf:prometheus-client) and a
+      downstream sink (otelcol:cos-agent), so it should reach ActiveStatus.
+    - otelcol receives the scrape job and begins scraping telegraf's /metrics endpoint.
+    """
+    juju.deploy(UBUNTU_APP_NAME, channel="latest/stable", base=TELEGRAF_BASE)
+    juju.deploy(TELEGRAF_APP_NAME, channel="latest/stable")
+    juju.integrate(f"{TELEGRAF_APP_NAME}:juju-info", f"{UBUNTU_APP_NAME}:juju-info")
+    juju.integrate(
+        f"{APP_NAME}:prometheus-target",
+        f"{TELEGRAF_APP_NAME}:prometheus-client",
+    )
+    juju.wait(
+        lambda status: jubilant.all_active(status, APP_NAME),
+        error=jubilant.any_error,
+        timeout=25 * 60,
+        delay=10,
+        successes=3,
+    )
+
+
+@retry(stop=stop_after_attempt(20), wait=wait_fixed(15))
+def test_scrape_jobs_appear_in_otelcol_logs(juju: Juju):
+    """Verify that otelcol is scraping telegraf metrics with correct Juju topology labels.
+
+    The debug exporter writes collected data points to snap logs. We grep for:
+    - juju_application=cos-proxy: the label injected by cos-proxy's scrape job config.
+      cos-proxy labels the scrape job with its own topology (not telegraf's), so the
+      scrape-config label wins over telegraf's embedded juju_application=ubuntu label.
+    - conntrack_ip_conntrack_count: a telegraf-specific metric that proves the scrape
+      target (telegraf's /metrics endpoint on port 9103) is actually being reached.
+      This metric cannot originate from otelcol's own node-exporter or self-monitoring.
+    """
+    grep_filters = [
+        "juju_application=cos-proxy",
+        "conntrack_ip_conntrack_count",
+    ]
+    assert_pattern_in_snap_logs(juju, grep_filters)
+
+
+def test_remove_telegraf_relation(juju: Juju):
+    """Remove the prometheus-target relation between cos-proxy and telegraf.
+
+    cos-proxy should process the relation-departed event, clear the stored scrape
+    job for telegraf, and update the cos-agent databag. otelcol regenerates its
+    config without telegraf's receiver.
+    """
+    juju.remove_relation(
+        f"{APP_NAME}:prometheus-target",
+        f"{TELEGRAF_APP_NAME}:prometheus-client",
+    )
+    juju.wait(
+        lambda status: jubilant.all_blocked(status, APP_NAME),
+        timeout=10 * 60,
+        delay=10,
+        successes=3,
+    )
+
+
+@retry(stop=stop_after_attempt(10), wait=wait_fixed(10))
+def test_scrape_jobs_absent_from_otelcol_config(juju: Juju):
+    """Verify that otelcol's generated config no longer references telegraf after removal.
+
+    We check the generated config file rather than snap logs because snap log history
+    is cumulative and cannot prove absence of new entries.
+
+    The config file is regenerated by otelcol whenever it processes updated cos-agent
+    relation data, so its absence here proves the removal propagated correctly.
+    """
+    assert_pattern_absent_in_otelcol_config(juju, TELEGRAF_APP_NAME)

--- a/tests/integration/test_scrape_jobs.py
+++ b/tests/integration/test_scrape_jobs.py
@@ -91,16 +91,7 @@ def test_deploy_telegraf_and_integrate(juju: Juju):
 
 @retry(stop=stop_after_attempt(20), wait=wait_fixed(15))
 def test_scrape_jobs_appear_in_otelcol_logs(juju: Juju):
-    """Verify that otelcol is scraping telegraf metrics with correct Juju topology labels.
-
-    The debug exporter writes collected data points to snap logs. We grep for:
-    - juju_application=cos-proxy: the label injected by cos-proxy's scrape job config.
-      cos-proxy labels the scrape job with its own topology (not telegraf's), so the
-      scrape-config label wins over telegraf's embedded juju_application=ubuntu label.
-    - conntrack_ip_conntrack_count: a telegraf-specific metric that proves the scrape
-      target (telegraf's /metrics endpoint on port 9103) is actually being reached.
-      This metric cannot originate from otelcol's own node-exporter or self-monitoring.
-    """
+    """Verify that otelcol is scraping telegraf metrics with correct Juju topology labels."""
     grep_filters = [
         "juju_application=cos-proxy",
         "conntrack_ip_conntrack_count",

--- a/tests/integration/test_scrape_jobs.py
+++ b/tests/integration/test_scrape_jobs.py
@@ -44,14 +44,7 @@ def test_deploy_cos_proxy(juju: Juju, charm: str):
 
 
 def test_deploy_otelcol_and_integrate(juju: Juju):
-    """Deploy otelcol with metrics debug exporter, integrate with cos-proxy via cos-agent.
-
-    otelcol is the sink for scrape jobs emitted by cos-proxy. The debug exporter writes
-    scraped metrics to snap logs, allowing grep-based verification.
-
-    cos-proxy remains in BlockedStatus after this step: it has a downstream sink
-    (cos-agent) but no upstream source yet.
-    """
+    """Deploy otelcol with metrics debug exporter, integrate with cos-proxy via cos-agent."""
     deploy_otelcol(juju, debug_exporter_for_metrics=True)
     juju.integrate(
         f"{APP_NAME}:cos-agent",

--- a/tox.ini
+++ b/tox.ini
@@ -21,8 +21,6 @@ setenv =
 passenv =
   PYTHONPATH
   CHARM_PATH
-  JUJU_CONTROLLER
-  OTELCOL_CHARM_PATH
 
 [testenv:lock]
 description = Update uv.lock with the latest deps

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,8 @@ setenv =
 passenv =
   PYTHONPATH
   CHARM_PATH
+  JUJU_CONTROLLER
+  OTELCOL_CHARM_PATH
 
 [testenv:lock]
 description = Update uv.lock with the latest deps


### PR DESCRIPTION
This is the way we could do integration testing for cos-proxy. It uses real charms we tested with in #215 but tries to define the first set of tests that actually make us more certain we're not breaking cos-proxy.